### PR TITLE
feat(web): add contribution page for community involvement

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -52,6 +52,9 @@ const DistrictComparisonPage = lazy(() =>
 const MethodologyPage = lazy(() =>
   import('./pages/MethodologyPage').then((m) => ({ default: m.MethodologyPage }))
 );
+const ContributePage = lazy(() =>
+  import('./pages/ContributePage').then((m) => ({ default: m.ContributePage }))
+);
 
 function PageLoader() {
   return (
@@ -92,6 +95,7 @@ const App = () => {
 
             <Route path="about" element={<AboutPage />} />
             <Route path="metodologia" element={<MethodologyPage />} />
+            <Route path="contribuir" element={<ContributePage />} />
 
             {/* Report Card Feature */}
             <Route path="report-card" element={<HomePage />} />

--- a/apps/web/src/pages/ContributePage/ContributePage.tsx
+++ b/apps/web/src/pages/ContributePage/ContributePage.tsx
@@ -1,0 +1,39 @@
+import Footer from '@/components/Footer';
+import MainNav from '@/components/MainNav';
+import { SEO } from '@/components/SEO';
+import { ArrowLeft } from 'lucide-react';
+import Markdown from 'react-markdown';
+import { Link } from 'react-router-dom';
+import remarkGfm from 'remark-gfm';
+import contributePtMd from './contribute-pt.md';
+
+const ContributePage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-neutral-2 flex flex-col">
+      <SEO
+        title="Contribuir | Debaixo d'Olho"
+        description="Como podes ajudar o projeto Debaixo d'Olho. Reportar bugs, validar correções, sugerir melhorias ou contribuir com código."
+        url="/contribuir"
+      />
+      <MainNav scrollY={0} />
+
+      <main className="flex-1 max-w-2xl mx-auto w-full px-4 py-8">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-neutral-11 hover:text-neutral-12 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          <span>Voltar</span>
+        </Link>
+
+        <article className="prose prose-neutral dark:prose-invert max-w-none">
+          <Markdown remarkPlugins={[remarkGfm]}>{contributePtMd}</Markdown>
+        </article>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default ContributePage;

--- a/apps/web/src/pages/ContributePage/contribute-pt.md
+++ b/apps/web/src/pages/ContributePage/contribute-pt.md
@@ -1,0 +1,108 @@
+# Contribuir
+
+O Debaixo d'Olho é um projeto **open source** e a tua ajuda é bem-vinda! Há várias formas de contribuir, independentemente do teu nível técnico.
+
+## Para Todos
+
+### Reportar Problemas
+Encontraste um erro ou algo que não funciona bem? Ajuda-nos a melhorar:
+
+1. Vai aos [GitHub Issues](https://github.com/bcamarneiro/adamastor/issues)
+2. Clica em "New Issue"
+3. Descreve o problema:
+   - O que estavas a fazer?
+   - O que esperavas que acontecesse?
+   - O que aconteceu realmente?
+   - Se possível, inclui uma captura de ecrã
+
+### Validar Correções
+Quando corrigimos um problema, precisamos de alguém para confirmar que está resolvido:
+
+1. Vai aos [issues com label "needs validation"](https://github.com/bcamarneiro/adamastor/issues?q=is%3Aissue+label%3A%22needs+validation%22)
+2. Segue os passos de validação descritos no issue
+3. Comenta se funcionou ou se ainda há problemas
+
+### Sugerir Melhorias
+Tens ideias para novas funcionalidades ou melhorias?
+
+1. Cria um [novo issue](https://github.com/bcamarneiro/adamastor/issues/new)
+2. Descreve a tua ideia e porque achas que seria útil
+3. Se possível, inclui exemplos ou mockups
+
+### Partilhar
+Ajuda-nos a chegar a mais pessoas:
+- Partilha o projeto nas redes sociais
+- Fala sobre ele com amigos e família
+- Menciona-o em discussões sobre transparência política
+
+## Para Técnicos
+
+### Investigar Issues
+Ajuda a diagnosticar problemas:
+
+1. Escolhe um [issue aberto](https://github.com/bcamarneiro/adamastor/issues?q=is%3Aissue+is%3Aopen)
+2. Tenta reproduzir o problema
+3. Investiga a causa
+4. Comenta com as tuas descobertas
+
+### Corrigir Bugs
+Queres resolver um problema?
+
+1. Comenta no issue que queres trabalhar nele
+2. Faz fork do repositório
+3. Cria uma branch: `git checkout -b fix/issue-XX-descricao`
+4. Faz as alterações e testa
+5. Abre um Pull Request referenciando o issue
+
+### Adicionar Funcionalidades
+Para novas funcionalidades:
+
+1. Discute primeiro no issue para alinhar a abordagem
+2. Segue o mesmo processo de fork + branch + PR
+3. Inclui testes se aplicável
+
+### Stack Técnica
+
+| Componente | Tecnologia |
+|------------|------------|
+| Frontend | React + TypeScript + Vite |
+| Styling | Tailwind CSS + Radix UI |
+| Backend | Supabase (PostgreSQL) |
+| Data Pipeline | Bun + TypeScript |
+| Monorepo | Turborepo |
+
+## Workflow de Contribuição
+
+```
+1. Issue criado (bug/feature)
+        ↓
+2. Alguém comenta que vai trabalhar
+        ↓
+3. Fork → Branch → Commit → PR
+        ↓
+4. Review de código
+        ↓
+5. Merge para staging
+        ↓
+6. Issue move para "Needs Validation"
+        ↓
+7. Validador confirma a correção
+        ↓
+8. Issue fechado ✓
+```
+
+## Código de Conduta
+
+- Sê respeitoso e construtivo
+- Foca-te no problema, não na pessoa
+- Aceita feedback com abertura
+- Ajuda outros contribuidores
+
+## Dúvidas?
+
+- Abre um [issue de discussão](https://github.com/bcamarneiro/adamastor/issues/new)
+- Consulta a [documentação do projeto](https://github.com/bcamarneiro/adamastor)
+
+---
+
+*Obrigado por considerares contribuir! Cada ajuda, por mais pequena que seja, faz diferença.*

--- a/apps/web/src/pages/ContributePage/index.ts
+++ b/apps/web/src/pages/ContributePage/index.ts
@@ -1,0 +1,1 @@
+export { default as ContributePage } from './ContributePage';


### PR DESCRIPTION
## Summary
- Create `/contribuir` page explaining how people can help the project
- Clear separation between technical and non-technical contributions

## For Non-Technical Contributors
- Report bugs (with guide on what to include)
- Validate fixes (link to issues needing validation)
- Suggest improvements
- Share the project

## For Technical Contributors
- Investigate issues
- Fix bugs (fork → branch → PR workflow)
- Add features
- Tech stack overview

## Workflow Diagram
Includes visual ASCII diagram of the contribution workflow from issue creation to closure.

Closes #80

## Validation Criteria
- [ ] Go to /contribuir
- [ ] Verify non-technical contribution options are explained
- [ ] Verify technical contribution workflow is clear
- [ ] Verify links to GitHub issues are present
- [ ] Verify page renders correctly in dark mode