### PR TITLE
chore(vercel): disable preview deployments

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,6 +4,7 @@
   "installCommand": "bun install",
   "framework": "vite",
   "outputDirectory": "dist",
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" = \"preview\" ]; then exit 0; else exit 1; fi",
   "git": {
     "deploymentEnabled": {
       "main": true,


### PR DESCRIPTION
## Summary
- Skip preview builds for PRs to avoid misleading CI status
- Only production (main) and staging branches will trigger deploys

## Changes
- Added `ignoreCommand` to `vercel.json` that exits early for preview environment

This prevents the confusing "Vercel - Authorization required" status on PRs.