### PR TITLE
fix(postal): move 3700, 3720, 3730 from Viseu to Aveiro

### DIFF
--- a/apps/watcher/src/transform/district-data.ts
+++ b/apps/watcher/src/transform/district-data.ts
@@ -3,6 +3,9 @@
 // Based on official CTT data and concelho (municipality) boundaries
 export const DISTRICT_POSTAL_PREFIXES: Record<string, string[]> = {
   Aveiro: [
+    '3700', // São João da Madeira (electoral circle: Aveiro)
+    '3720', // Oliveira de Azeméis (electoral circle: Aveiro)
+    '3730', // Vale de Cambra (electoral circle: Aveiro)
     '3750',
     '3800',
     '3810',
@@ -548,9 +551,7 @@ export const DISTRICT_POSTAL_PREFIXES: Record<string, string[]> = {
     '3670',
     '3680',
     '3690',
-    '3700',
-    '3720',
-    '3730',
+    // 3700, 3720, 3730 belong to Aveiro (São João da Madeira, Oliveira de Azeméis, Vale de Cambra)
     // 4540 belongs to Aveiro (Arouca)
     '4660', // Resende, Cinfães
     '4690', // Cinfães

--- a/supabase/migrations/20250105000001_fix_postal_code_sao_joao_madeira.sql
+++ b/supabase/migrations/20250105000001_fix_postal_code_sao_joao_madeira.sql
@@ -1,0 +1,20 @@
+-- =========================================
+-- Fix postal code mappings for Aveiro municipalities
+-- =========================================
+-- Issue: #116
+-- Problem: Postal codes 3700, 3720, 3730 were incorrectly mapped to Viseu.
+--          These belong to Aveiro district and electoral circle:
+--          - 3700: São João da Madeira
+--          - 3720: Oliveira de Azeméis
+--          - 3730: Vale de Cambra
+--
+-- Solution: Move 3700, 3720, 3730 from Viseu to Aveiro.
+-- =========================================
+
+-- Add 3700, 3720, 3730 to Aveiro
+UPDATE districts SET postal_prefixes = ARRAY['3700', '3720', '3730', '3750', '3800', '3810', '3830', '3840', '3850', '3860', '3870', '3880', '4500', '4505', '4520', '4535', '4540', '4550']
+WHERE slug = 'aveiro';
+
+-- Remove 3700, 3720, 3730 from Viseu
+UPDATE districts SET postal_prefixes = ARRAY['3440', '3460', '3465', '3475', '3500', '3505', '3510', '3515', '3520', '3525', '3530', '3535', '3540', '3550', '3560', '3570', '3580', '3590', '3600', '3610', '3620', '3630', '3640', '3650', '3660', '3670', '3680', '3690', '4660', '4690']
+WHERE slug = 'viseu';


### PR DESCRIPTION
## Summary
- Moves postal codes 3700, 3720, 3730 from Viseu to Aveiro electoral circle
- These postal codes correspond to municipalities in Aveiro district:
  - 3700: São João da Madeira
  - 3720: Oliveira de Azeméis
  - 3730: Vale de Cambra

## Test Plan
- [x] Run postal code validation script (`bun run scripts/validate-postal-codes.ts`)
- [x] Verify 3700, 3720, 3730 no longer appear in mismatches
- [ ] Manual test: Enter postal code 3700-XXX and verify Aveiro deputies are shown

## Validation Criteria
- [ ] Go to https://debaixodolho.pt
- [ ] Enter postal code 3700-100 (São João da Madeira)
- [ ] Verify that Aveiro deputies are shown (not Viseu)
- [ ] Repeat with 3720-100 (Oliveira de Azeméis) and 3730-100 (Vale de Cambra)

Closes #116