### PR TITLE
chore(e2e): add regression tests for closed issues

### DIFF
--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -22,4 +22,105 @@ test.describe('Home Page', () => {
     const footer = page.locator('footer');
     await expect(footer).toBeVisible();
   });
+
+  // Issue #35: Footer section titles low contrast
+  // @see https://github.com/bcamarneiro/adamastor/issues/35
+  test('footer should have readable section titles', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const footer = page.locator('footer');
+    await expect(footer).toBeVisible();
+
+    const footerHeadings = footer.locator('h3, h4, [class*="title"], strong');
+
+    if ((await footerHeadings.count()) > 0) {
+      const firstHeading = footerHeadings.first();
+      await expect(firstHeading).toBeVisible();
+
+      const headingText = await firstHeading.textContent();
+      expect(headingText?.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  // Issue #90: Loading string flash
+  // @see https://github.com/bcamarneiro/adamastor/issues/90
+  test('should not flash "assembleia" loading text', async ({ page }) => {
+    await page.goto('/');
+
+    const assembleiaText = page.getByText(/^assembleia$/i);
+
+    await expect(assembleiaText)
+      .not.toBeVisible({ timeout: 1000 })
+      .catch(() => {
+        throw new Error('"assembleia" loading text was visible - regression of #90');
+      });
+  });
+
+  // Issue #92: Homepage tabs broken
+  // @see https://github.com/bcamarneiro/adamastor/issues/92
+  test('should display content sections', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const heroSection = page.locator('section, [class*="hero"]').first();
+    await expect(heroSection).toBeVisible();
+
+    const emptyFeatureSection = page
+      .locator('section')
+      .filter({ hasText: /funcionalidades/i })
+      .filter({ hasText: '' });
+
+    const emptyCount = await emptyFeatureSection.count();
+    expect(emptyCount).toBe(0);
+  });
+
+  // Issue #92: Homepage tabs broken
+  // @see https://github.com/bcamarneiro/adamastor/issues/92
+  test('tabs should be clickable if present', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const tabList = page.getByRole('tablist').first();
+
+    if ((await tabList.count()) > 0) {
+      const tabs = tabList.getByRole('tab');
+      const tabCount = await tabs.count();
+
+      if (tabCount > 1) {
+        await tabs.nth(1).click();
+        await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+
+        const tabPanel = page.getByRole('tabpanel').first();
+        const panelText = await tabPanel.textContent();
+        expect(panelText?.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  // Issue #93: "Começar Agora" button link
+  // @see https://github.com/bcamarneiro/adamastor/issues/93
+  test('"Começar Agora" button should link to /contribuir', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const comecarButton = page.getByRole('link', { name: /começar agora/i }).first();
+
+    if ((await comecarButton.count()) === 0) {
+      const altButton = page
+        .locator('a')
+        .filter({ hasText: /começar agora/i })
+        .first();
+      if ((await altButton.count()) === 0) {
+        test.skip();
+        return;
+      }
+      await altButton.click();
+    } else {
+      await comecarButton.click();
+    }
+
+    await page.waitForLoadState('networkidle');
+    expect(page.url()).toContain('/contribuir');
+  });
 });

--- a/apps/web/e2e/leaderboard.spec.ts
+++ b/apps/web/e2e/leaderboard.spec.ts
@@ -42,4 +42,43 @@ test.describe('Leaderboard Page', () => {
       }
     }
   });
+
+  // Issue #67: Ranking numbers exceed deputy count
+  // @see https://github.com/bcamarneiro/adamastor/issues/67
+  test('no ranking position should exceed 230', async ({ page }) => {
+    await page.goto('/ranking');
+    await page.waitForLoadState('networkidle');
+
+    const rankElements = page.locator('text=/#\\d+/');
+    const ranks = await rankElements.allTextContents();
+
+    for (const rankText of ranks) {
+      const match = rankText.match(/#(\d+)/);
+      if (match) {
+        const rank = Number.parseInt(match[1], 10);
+        expect(rank).toBeLessThanOrEqual(230);
+      }
+    }
+  });
+
+  // Issue #68: Suspended deputies in ranking
+  // @see https://github.com/bcamarneiro/adamastor/issues/68
+  test('should not show suspended deputies in low activity section', async ({ page }) => {
+    await page.goto('/ranking');
+    await page.waitForLoadState('networkidle');
+
+    const lowActivitySection = page.locator('section, div').filter({
+      hasText: /menor atividade|ranking de preguiça/i,
+    });
+
+    if ((await lowActivitySection.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    const suspendedBadges = lowActivitySection.getByText(/suspenso|suspens/i);
+    const suspendedCount = await suspendedBadges.count();
+
+    expect(suspendedCount).toBe(0);
+  });
 });

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -52,4 +52,71 @@ test.describe('Navigation', () => {
     // Should be back on home page
     await expect(page).toHaveURL('/');
   });
+
+  // Issue #20: Hidden pages navigation
+  // @see https://github.com/bcamarneiro/adamastor/issues/20
+  test('footer should have links to informational pages', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const footer = page.locator('footer');
+    await expect(footer).toBeVisible();
+
+    const expectedLinks = [
+      { name: /metodologia/i, url: '/metodologia' },
+      { name: /contribuir/i, url: '/contribuir' },
+      { name: /missão|sobre/i, url: '/missao' },
+    ];
+
+    for (const link of expectedLinks) {
+      const footerLink = footer.getByRole('link', { name: link.name }).first();
+
+      if ((await footerLink.count()) > 0) {
+        const href = await footerLink.getAttribute('href');
+        expect(href).toContain(link.url);
+      }
+    }
+  });
+
+  // Issue #20: Hidden pages navigation
+  // @see https://github.com/bcamarneiro/adamastor/issues/20
+  test('/metodologia page should be accessible', async ({ page }) => {
+    await page.goto('/metodologia');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('body')).not.toHaveText(/404|not found/i);
+
+    const mainContent = await page.textContent('main, article, [class*="content"]');
+    expect(mainContent?.length).toBeGreaterThan(100);
+  });
+
+  // Issue #20: Hidden pages navigation
+  // @see https://github.com/bcamarneiro/adamastor/issues/20
+  test('/contribuir page should be accessible', async ({ page }) => {
+    await page.goto('/contribuir');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('body')).not.toHaveText(/404|not found/i);
+
+    const mainContent = await page.textContent('main, article, [class*="content"]');
+    expect(mainContent?.length).toBeGreaterThan(100);
+  });
+
+  // Issue #20: Hidden pages navigation
+  // @see https://github.com/bcamarneiro/adamastor/issues/20
+  test('/missao page should be accessible', async ({ page }) => {
+    await page.goto('/missao');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('body')).not.toHaveText(/404|not found/i);
+  });
+
+  // Issue #21: Remove unused WhatHappened page
+  // @see https://github.com/bcamarneiro/adamastor/issues/21
+  test('/what-happened should not exist (returns 404)', async ({ page }) => {
+    const response = await page.goto('/what-happened');
+
+    const status = response?.status();
+    expect(status === 404 || page.url() !== '/what-happened').toBeTruthy();
+  });
 });

--- a/apps/web/e2e/parties.spec.ts
+++ b/apps/web/e2e/parties.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from './fixtures';
+
+test.describe('Parties Page', () => {
+  test('should load the parties page', async ({ page }) => {
+    await page.goto('/partidos');
+
+    await expect(page).toHaveURL(/\/partidos/);
+  });
+
+  // Issue #25: Party colors transparency in dark mode
+  // @see https://github.com/bcamarneiro/adamastor/issues/25
+  test('party cards should have visible colors', async ({ page }) => {
+    await page.goto('/partidos');
+    await page.waitForLoadState('networkidle');
+
+    const partyCards = page.locator('[class*="party"], [data-party]');
+
+    if ((await partyCards.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    const firstCard = partyCards.first();
+    await expect(firstCard).toBeVisible();
+  });
+
+  // Issue #45: "Comparar Partidos" button illegible
+  // @see https://github.com/bcamarneiro/adamastor/issues/45
+  test('compare parties button should be visible', async ({ page }) => {
+    await page.goto('/partidos');
+    await page.waitForLoadState('networkidle');
+
+    const compareButton = page
+      .getByRole('button', { name: /comparar/i })
+      .or(page.locator('button').filter({ hasText: /comparar/i }))
+      .first();
+
+    if ((await compareButton.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    await expect(compareButton).toBeVisible();
+
+    const buttonText = await compareButton.textContent();
+    expect(buttonText?.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/e2e/postal-codes.spec.ts
+++ b/apps/web/e2e/postal-codes.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from './fixtures';
+
+test.describe('Postal Code Lookup', () => {
+  // Issue #116: Postal code 3700 shows wrong district
+  // @see https://github.com/bcamarneiro/adamastor/issues/116
+  test('postal code 3700 should map to Aveiro district', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const postalInput = page.getByPlaceholder(/1000-001|código postal/i).first();
+
+    if ((await postalInput.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    await postalInput.fill('3700');
+
+    const submitButton = page.locator('button[type="submit"]').first();
+    if ((await submitButton.count()) > 0) {
+      await submitButton.click();
+    } else {
+      await postalInput.press('Enter');
+    }
+
+    await page.waitForLoadState('networkidle');
+
+    const pageContent = await page.textContent('body');
+
+    const mentionsViseuAsDistrict =
+      pageContent?.includes('Viseu') && !pageContent?.includes('Aveiro');
+
+    if (page.url().includes('/deputados') || page.url().includes('/distrito')) {
+      expect(page.url()).toContain('aveiro');
+    }
+
+    expect(mentionsViseuAsDistrict).toBeFalsy();
+    expect(page.url()).not.toContain('error');
+  });
+
+  // Issue #116: Postal code 3720 (Oliveira de Azeméis)
+  // @see https://github.com/bcamarneiro/adamastor/issues/116
+  test('postal code 3720 should map to Aveiro', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const postalInput = page.getByPlaceholder(/1000-001|código postal/i).first();
+    if ((await postalInput.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    await postalInput.fill('3720');
+
+    const submitButton = page.locator('button[type="submit"]').first();
+    if ((await submitButton.count()) > 0) {
+      await submitButton.click();
+    } else {
+      await postalInput.press('Enter');
+    }
+
+    await page.waitForLoadState('networkidle');
+
+    if (page.url().includes('/deputados') || page.url().includes('/distrito')) {
+      expect(page.url()).toContain('aveiro');
+    }
+  });
+
+  // Issue #109: Postal code mappings incorrect
+  // @see https://github.com/bcamarneiro/adamastor/issues/109
+  test('postal code 6300 should map to Guarda (not Castelo Branco)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const postalInput = page.getByPlaceholder(/1000-001|código postal/i).first();
+    if ((await postalInput.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    await postalInput.fill('6300');
+
+    const submitButton = page.locator('button[type="submit"]').first();
+    if ((await submitButton.count()) > 0) {
+      await submitButton.click();
+    } else {
+      await postalInput.press('Enter');
+    }
+
+    await page.waitForLoadState('networkidle');
+
+    if (page.url().includes('/deputados') || page.url().includes('/distrito')) {
+      expect(page.url()).toContain('guarda');
+      expect(page.url()).not.toContain('castelo-branco');
+    }
+  });
+
+  // Issue #109: Postal code 2800 (Almada area)
+  // @see https://github.com/bcamarneiro/adamastor/issues/109
+  test('postal code 2800 should map to Setúbal', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const postalInput = page.getByPlaceholder(/1000-001|código postal/i).first();
+    if ((await postalInput.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    await postalInput.fill('2800');
+
+    const submitButton = page.locator('button[type="submit"]').first();
+    if ((await submitButton.count()) > 0) {
+      await submitButton.click();
+    } else {
+      await postalInput.press('Enter');
+    }
+
+    await page.waitForLoadState('networkidle');
+
+    if (page.url().includes('/deputados') || page.url().includes('/distrito')) {
+      expect(page.url()).toContain('setubal');
+      expect(page.url()).not.toContain('lisboa');
+    }
+  });
+});

--- a/docs/AI_AGENTS.md
+++ b/docs/AI_AGENTS.md
@@ -25,6 +25,12 @@ This document provides guidelines for AI agents (Cursor, GitHub Copilot, Claude 
 - **Clear commit messages** - Describe what changed and why
 - **Incremental improvements** - Build up complex features in small steps
 
+### Branching Strategy
+
+- **All PRs target `staging`** - Never create PRs directly to `main`
+- **Create feature branches from `staging`** - `git checkout staging && git pull && git checkout -b <type>/issue-<n>-<desc>`
+- **Branch naming**: `fix/`, `feat/`, `refactor/`, `docs/`, `chore/` + issue number + short description
+
 ---
 
 ## Tool-Specific Guidance
@@ -342,6 +348,40 @@ export const mockParties = [
 // In test file
 import { mockParties } from './__fixtures__/parties';
 ```
+
+### E2E Regression Tests for Bug Fixes
+
+**Location:** Add tests to the appropriate thematic spec file in `apps/web/e2e/`:
+
+- `home.spec.ts` - Homepage-related bugs
+- `navigation.spec.ts` - Navigation and page accessibility bugs
+- `leaderboard.spec.ts` - Ranking page bugs
+- `postal-codes.spec.ts` - Postal code mapping bugs
+- `parties.spec.ts` - Party page bugs
+
+When fixing user-reported bugs, **always add an E2E regression test** to prevent the bug from returning:
+
+```typescript
+// Issue #116: Postal code 3700 shows wrong district
+// @see https://github.com/bcamarneiro/adamastor/issues/116
+test('postal code 3700 should map to Aveiro district', async ({ page }) => {
+  await page.goto('/');
+  // ... test implementation
+});
+```
+
+**Pattern:**
+
+1. Add a comment with `// Issue #XX: Title` and `// @see <github-url>`
+2. Test the specific user flow that was broken
+3. Skip tests gracefully if prerequisite UI elements don't exist
+
+**Bug-fixing workflow checklist:**
+
+- [ ] Fix the bug
+- [ ] Add E2E test to the appropriate spec file referencing the issue
+- [ ] Verify test passes locally: `cd apps/web && npx playwright test <spec-file>`
+- [ ] Create PR targeting `staging` and linking to the issue
 
 ---
 


### PR DESCRIPTION
## Summary
Add E2E regression tests for previously closed user-reported bugs and document branching strategy.

## Changes

### New E2E Tests
Tests distributed across thematic spec files to prevent regressions:

| File | Issues Covered |
|------|----------------|
| `home.spec.ts` | #35, #90, #92, #93 |
| `navigation.spec.ts` | #20, #21 |
| `leaderboard.spec.ts` | #67, #68 |
| `postal-codes.spec.ts` (new) | #109, #116 |
| `parties.spec.ts` (new) | #25, #45 |

### Documentation Updates
- Added **Branching Strategy** section to AI_AGENTS.md
  - All PRs must target `staging` (never `main`)
  - Branch naming convention documented
- Updated E2E test documentation to reflect thematic organization

## Test Plan
- [ ] Run `cd apps/web && npx playwright test` to verify all E2E tests pass
- [ ] Verify new postal code tests work with various inputs
- [ ] Confirm party page tests work with compare button