### PR TITLE
fix(web): add worker-src to CSP for Sentry web workers

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -42,7 +42,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://*.vercel-scripts.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.supabase.co https://app.parlamento.pt; connect-src 'self' https://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://*.vercel-insights.com; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' https://*.vercel-scripts.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.supabase.co https://app.parlamento.pt; connect-src 'self' https://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://*.vercel-insights.com; worker-src 'self' blob:; frame-ancestors 'none'"
         }
       ]
     }


### PR DESCRIPTION
## Problem

Production release workflow failed on e2e smoke tests with CSP error:
```
Creating a worker from 'blob:https://adamastor-staging.vercel.app/...' violates 
Content Security Policy directive: "script-src 'self' https://*.vercel-scripts.com". 
Note that 'worker-src' was not explicitly set, so 'script-src' is used as a fallback.
```

## Root Cause

Sentry (@sentry/react) uses web workers for performance monitoring, creating them from blob URLs. The CSP policy was missing `worker-src` directive, causing it to fall back to `script-src` which doesn't allow `blob:` URLs.

## Solution

Added `worker-src 'self' blob:` to CSP policy in [apps/web/vercel.json](apps/web/vercel.json:45) to explicitly allow:
- Web workers from same origin ('self')
- Web workers created from blob: URLs (needed by Sentry)

## Testing

Once merged and deployed to staging, the production release workflow e2e smoke tests should pass.

Blocks production release until fixed.

Closes #164