### PR TITLE
fix(watcher): replace parallel photo processing with sequential to fix Bun crash

### DIFF
--- a/apps/watcher/src/sync-photos.ts
+++ b/apps/watcher/src/sync-photos.ts
@@ -208,44 +208,37 @@ async function main() {
   let successCount = 0;
   let failCount = 0;
 
-  // Process in batches to avoid overwhelming the server
-  const batchSize = 5;
+  // Process sequentially to avoid Bun memory corruption with Sharp library
+  // See: https://github.com/bcamarneiro/adamastor/issues/192
+  let processed = 0;
+  for (const deputy of deputies) {
+    const result = await syncPhotoForDeputy(deputy, options.dryRun);
+    results.push(result);
 
-  for (let i = 0; i < deputies.length; i += batchSize) {
-    const batch = deputies.slice(i, i + batchSize);
-
-    const batchResults = await Promise.all(
-      batch.map((deputy) => syncPhotoForDeputy(deputy, options.dryRun))
-    );
-
-    for (const result of batchResults) {
-      results.push(result);
-
-      if (result.success) {
-        successCount++;
-        if (result.photoUrl) {
-          // Show the source of the photo (biography page or Parliament API)
-          console.log(`✅ ${result.name}: uploaded ${result.reason || ''}`);
-        } else {
-          console.log(`✅ ${result.name}: ${result.reason}`);
-        }
+    if (result.success) {
+      successCount++;
+      if (result.photoUrl) {
+        // Show the source of the photo (biography page or Parliament API)
+        console.log(`✅ ${result.name}: uploaded ${result.reason || ''}`);
       } else {
-        failCount++;
-        console.log(`❌ ${result.name}: ${result.reason}`);
+        console.log(`✅ ${result.name}: ${result.reason}`);
       }
+    } else {
+      failCount++;
+      console.log(`❌ ${result.name}: ${result.reason}`);
+    }
+
+    // Small delay between photos to reduce memory pressure
+    processed++;
+    if (processed < deputies.length) {
+      await new Promise((resolve) => setTimeout(resolve, 200));
     }
 
     // Progress update every 25 deputies
-    const processed = Math.min(i + batchSize, deputies.length);
     if (processed % 25 === 0 || processed === deputies.length) {
       console.log(
         `\n📊 Progress: ${processed}/${deputies.length} (${successCount} ok, ${failCount} failed)\n`
       );
-    }
-
-    // Small delay between batches to be respectful to the server
-    if (i + batchSize < deputies.length) {
-      await new Promise((resolve) => setTimeout(resolve, 500));
     }
   }
 

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
       "supabase/.temp",
       "tsconfig*.json",
       "*.d.ts",
-      "**/public/data"
+      "**/public/data",
+      "**/snapshots/**"
     ]
   },
   "organizeImports": {


### PR DESCRIPTION
Closes #192

## What
Replaces Promise.all() parallel processing with sequential for...of loop in photo sync script to prevent Bun memory corruption crashes.

## Why
The parallel processing of 5 photos concurrently using Sharp library was causing 'pas panic: deallocation did fail' memory corruption crashes in Bun runtime after processing ~25 photos out of 136 total. This fatal error prevented the entire sync workflow from completing.

## How
- Changed from batch processing with Promise.all() to sequential processing with for...of loop
- Added 200ms delay between photo processing to reduce memory pressure
- Updated progress tracking to use a counter variable instead of array index
- Also added **/snapshots/** to Biome ignore list to prevent unrelated lint failures

## Testing
- [x] Code passes TypeScript compilation
- [x] Sequential processing eliminates array indexing type errors
- [ ] Manual testing on staging (needs deployment to verify no crashes)
- [ ] Full photo sync completes without Bun crashes (136 deputies)

## Related
- Issue #192: Bug report with full error logs and investigation
- Root cause: Sharp library + Bun runtime memory management conflict during concurrent operations