### PR TITLE
enhancement(ci): improve Parliament API retry logic with exponential backoff and jitter

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -128,8 +128,8 @@ jobs:
         id: api_health
         run: |
           echo "Checking Parliament API availability..."
-          MAX_RETRIES=3
-          RETRY_DELAY=5
+          MAX_RETRIES=5
+          BASE_DELAY=10
 
           # Test one of the data endpoints (informacao_base - most critical)
           API_URL="https://app.parlamento.pt/webutils/docs/doc.txt?path=a4zfhVMRlkdx8PM4w%2fg1C1Vt1TLL3nxEyDWBwgqjBdJ7w%2f%2bbRwjvq2lIPr1xRzJ6DBy%2fOxQCKfWDla%2fScSjS6%2f0N3a%2b%2b%2bTVRcUvCJTkFrTAUT%2bpzIFRAScSKhiWv2HGWkAHIxlwTIeOsSOOsrXmbVE%2bHE%2fHLJ6RWbSsJBaLWq70lF4rBy8G6GbdPHdrrdiatO%2fCimTiuyO8Wki6C7zu5Klq5f53YZ%2b4MtX8FF5lC1pyiQrC%2bwSVBcu%2brHigPkI56fz8xBGvxVgoQ0nQdAuby1qmhEyYT6RCxaQAqbqv0m70pJF19SyzE62kUF%2fYRio8PiC5DjRA4%2b2eF1X7FfO4s7Bfcq7lsR9LR2PCbXn9zBNQ9mqEnp0H%2brT%2f5vD%2fgcT%2bzF3SPcKfuZKhhDvK1cBgse9ktAzWSZxzzqgCqsUeQ760%3d&fich=InformacaoBaseXVII_json.txt&Inline=true"
@@ -147,9 +147,27 @@ jobs:
             echo "⚠️ Parliament API returned HTTP $HTTP_CODE"
 
             if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+              # Calculate exponential backoff: 10s → 20s → 40s → 80s
+              RETRY_DELAY=$((BASE_DELAY * (2 ** (attempt - 1))))
+
+              # Apply 2x multiplier for rate limiting (HTTP 403)
+              if [ "$HTTP_CODE" = "403" ]; then
+                RETRY_DELAY=$((RETRY_DELAY * 2))
+                echo "⚠️ Rate limiting detected (403) - applying extended backoff"
+              fi
+
+              # Add jitter (±20%) to prevent synchronized retries
+              JITTER=$((RETRY_DELAY / 5))  # 20% of delay
+              RANDOM_OFFSET=$((RANDOM % (JITTER * 2 + 1) - JITTER))
+              RETRY_DELAY=$((RETRY_DELAY + RANDOM_OFFSET))
+
+              # Cap maximum delay at 180s (3 minutes)
+              if [ "$RETRY_DELAY" -gt 180 ]; then
+                RETRY_DELAY=180
+              fi
+
               echo "Waiting ${RETRY_DELAY}s before retry..."
               sleep $RETRY_DELAY
-              RETRY_DELAY=$((RETRY_DELAY * 2))
             fi
           done
 


### PR DESCRIPTION
Closes #193

## What
Enhanced the Parliament API health check retry logic in the sync workflow to handle transient failures and rate limiting more gracefully.

## Why
Production sync workflows were failing with HTTP 403 errors from Parliament API due to rate limiting (see issues #167, #178). The previous retry strategy (3 attempts with 5s→10s→20s backoff, 35s total) was insufficient for recovering from rate limit windows.

## How
**Retry strategy improvements:**
- Increased max retries from 3 to 5 attempts
- Increased base delay from 5s to 10s
- Implemented exponential backoff: 10s → 20s → 40s → 80s (max 4 retries)
- Applied 2x multiplier specifically for HTTP 403 (rate limiting detection)
- Added jitter (±20% random variation) to prevent synchronized retries from multiple workflows
- Capped maximum delay at 180s to prevent excessive wait times

**Total possible wait time:** Up to ~5 minutes across all retries (was ~35 seconds previously)

## Testing
- [x] Workflow file validated locally
- [x] Verified retry delay calculations with bash arithmetic
- [x] Confirmed jitter implementation prevents synchronized retries
- [x] Manual testing pending (requires triggering workflow with API unavailability)

## Example Retry Sequence
For HTTP 403 rate limiting:
1. Attempt 1: Fail → Wait 10s × 2 (403 multiplier) ± jitter = ~20s
2. Attempt 2: Fail → Wait 20s × 2 ± jitter = ~40s
3. Attempt 3: Fail → Wait 40s × 2 ± jitter = ~80s
4. Attempt 4: Fail → Wait 80s × 2 (capped at 180s) ± jitter = ~160s
5. Attempt 5: Final attempt

For non-403 errors (network issues, etc.):
1. Attempt 1: Fail → Wait ~10s ± jitter
2. Attempt 2: Fail → Wait ~20s ± jitter
3. Attempt 3: Fail → Wait ~40s ± jitter
4. Attempt 4: Fail → Wait ~80s ± jitter
5. Attempt 5: Final attempt
