### PR TITLE
test(web): add comprehensive e2e tests for content pages

### DIFF
--- a/apps/web/e2e/content-pages.spec.ts
+++ b/apps/web/e2e/content-pages.spec.ts
@@ -65,7 +65,7 @@ test.describe('Content Pages', () => {
 
       const title = await page.title();
       expect(title).toContain('Metodologia');
-      expect(title).toContain('Debaixo d\'olho');
+      expect(title).toContain("Debaixo d'olho");
     });
 
     test('should have links that are valid', async ({ page }) => {
@@ -148,7 +148,7 @@ test.describe('Content Pages', () => {
 
       const title = await page.title();
       expect(title).toContain('Contribuir');
-      expect(title).toContain('Debaixo d\'olho');
+      expect(title).toContain("Debaixo d'olho");
     });
 
     test('should have GitHub links', async ({ page }) => {
@@ -246,7 +246,7 @@ test.describe('Content Pages', () => {
 
       const title = await page.title();
       expect(title).toContain('Missão');
-      expect(title).toContain('Debaixo d\'olho');
+      expect(title).toContain("Debaixo d'olho");
     });
 
     test('should have GitHub links', async ({ page }) => {


### PR DESCRIPTION
Closes #88

## What
Adds comprehensive Playwright e2e tests for the three static content pages: Metodologia, Contribuir, and Missão.

## Why
These pages previously lacked automated test coverage. E2E tests ensure these pages remain functional and accessible as the codebase evolves.

## How
- Created content-pages.spec.ts with 20 tests across 3 page categories
- Each page tests: successful load, content visibility, substantial content, back navigation, correct title, and valid links
- GitHub link validation for /contribuir and /missao pages
- Used JavaScript .click() for back button navigation to avoid fixed header z-index issues

## Testing
- [x] All 20 e2e tests passing locally
- [x] Lint checks passing
- [x] Type checks passing
- [x] Unit tests passing

## Test Coverage
**Methodology Page (/metodologia):**
- Loads successfully without errors
- Displays main content sections (nav, back button, article, footer)
- Has substantial content (>500 characters)
- Back button navigates to homepage
- Correct page title
- All links have valid href attributes

**Contribution Page (/contribuir):**
- Loads successfully without errors
- Displays main content sections
- Has substantial content
- Back button navigates to homepage
- Correct page title
- GitHub links point to correct repository
- All links have valid href attributes

**Mission Page (/missao):**
- Loads successfully without errors
- Displays main content sections
- Has substantial content
- Back button navigates to homepage
- Correct page title
- GitHub links point to correct repository
- All links have valid href attributes
