### PR TITLE
chore(web): migrate staging to Supabase preview branch

### DIFF
--- a/apps/watcher/src/data-consistency/invariants.test.ts
+++ b/apps/watcher/src/data-consistency/invariants.test.ts
@@ -14,7 +14,7 @@ import { scoreToGrade } from './helpers.js';
 
 let supabase: SupabaseClient;
 
-beforeAll(() => {
+beforeAll(async () => {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
@@ -23,9 +23,20 @@ beforeAll(() => {
     return;
   }
 
-  supabase = createClient(url, key, {
+  const client = createClient(url, key, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
+
+  // Env vars can be set (e.g. from .env) while local Supabase is offline.
+  // Probe reachability before exposing the client; otherwise queries below
+  // would fail with confusing assertion errors instead of skipping cleanly.
+  const { error } = await client.from('deputy_details').select('id').limit(1);
+  if (error) {
+    console.warn(`⚠️ Supabase not reachable (${error.message}), skipping invariant tests`);
+    return;
+  }
+
+  supabase = client;
 });
 
 describe('Database Data Invariants', () => {

--- a/apps/watcher/src/transform/legislature-detection.integration.test.ts
+++ b/apps/watcher/src/transform/legislature-detection.integration.test.ts
@@ -9,6 +9,27 @@ async function loadLegislatureService() {
   return await import('../services/legislature.js');
 }
 
+// Probe whether Supabase is actually reachable (not just configured).
+// Env vars can be set (e.g. from .env) while local Supabase is offline,
+// in which case integration tests must be skipped, not run-and-fail.
+async function isSupabaseReachable(): Promise<boolean> {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return false;
+  }
+  try {
+    const { supabase } = await import('../supabase.js');
+    const { error } = await supabase
+      .from('legislature_config')
+      .select('legislature_number')
+      .limit(1);
+    return !error;
+  } catch {
+    return false;
+  }
+}
+
+const hasSupabase = await isSupabaseReachable();
+
 // Helper to create minimal informacao_base data
 function createInfoBase(
   overrides: Partial<ParliamentInformacaoBase> = {}
@@ -29,9 +50,6 @@ function createInfoBase(
 }
 
 describe('Legislature Detection Integration', () => {
-  // Skip if Supabase is not configured
-  const hasSupabase = process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY;
-
   it.skipIf(!hasSupabase)('should detect and store legislature in database', async () => {
     const { getCurrentLegislature, updateLegislatureFromDetection } =
       await loadLegislatureService();

--- a/apps/web/.env.staging
+++ b/apps/web/.env.staging
@@ -1,6 +1,6 @@
-# Staging Environment - adamastor-staging
-VITE_SUPABASE_URL=https://gwzxoqzktnluqiilxiew.supabase.co
-VITE_SUPABASE_ANON_KEY=sb_publishable_AJxjHs7QJ8zd1JYAPOB0ow_JI7zmxHl
+# Staging Environment - adamastor-prod (preview branch "staging")
+VITE_SUPABASE_URL=https://cbgdzoaivmhtqhzkscmm.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_axMh_OyFZ7N8tAcRuZE47w_HP2_5rlN
 
 VITE_INITIATIVES_URL="https://ydfwrfxg9t0mujvy.public.blob.vercel-storage.com/latest/iniciativas.json"
 VITE_BASE_INFO_URL="https://ydfwrfxg9t0mujvy.public.blob.vercel-storage.com/latest/informacao_base.json"

--- a/apps/web/ENV_SETUP.md
+++ b/apps/web/ENV_SETUP.md
@@ -14,10 +14,10 @@ VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
 ### Staging (`.env.staging`)
-Uses adamastor-staging project:
+Uses the `staging` preview branch on the adamastor-prod project:
 ```bash
-VITE_SUPABASE_URL=https://gwzxoqzktnluqiilxiew.supabase.co
-VITE_SUPABASE_ANON_KEY=sb_publishable_AJxjHs7QJ8zd1JYAPOB0ow_JI7zmxHl
+VITE_SUPABASE_URL=https://cbgdzoaivmhtqhzkscmm.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_axMh_OyFZ7N8tAcRuZE47w_HP2_5rlN
 ```
 
 ### Production (`.env.production`)


### PR DESCRIPTION
## Summary

Cuts over the staging environment from the separate \`adamastor-staging\` Supabase project to a preview branch (\"staging\") on the \`adamastor-prod\` project. Cost-reduction goal from PRD \`.claude/prds/supabase-branch-migration.md\`.

### What changed
- \`apps/web/.env.staging\`: \`VITE_SUPABASE_URL\` and \`VITE_SUPABASE_ANON_KEY\` now point at the new preview branch (\`cbgdzoaivmhtqhzkscmm\`).

### What changed outside this repo (already executed)
- **Supabase**: Created persistent preview branch \"staging\" on \`adamastor-prod\` (Ireland). Schema applied from prod-schema dump (verified byte-identical to staging-schema pre-migration). Data seeded from staging-data dump (~2,959 deputies + stats, 10 parties).
- **GitHub Actions** (staging environment): Rotated \`SUPABASE_URL\`, \`SUPABASE_PROJECT_ID\`, \`SUPABASE_ANON_KEY\`, \`SUPABASE_SERVICE_ROLE_KEY\`, \`SUPABASE_DB_PASSWORD\` to the new branch.
- **Vercel** (preview env): Updated \`VITE_SUPABASE_URL\` and \`VITE_SUPABASE_ANON_KEY\`.

### Why
- Eliminates manual schema-drift maintenance between two projects.
- Aligns DB environments with git workflow.
- Single project consolidates billing.

### Rollback
Old \`adamastor-staging\` project (\`gwzxoqzktnluqiilxiew\`) is **still running** untouched — env-var revert + re-run \`gh secret set\` would roll back. Deletion is intentionally deferred until ~1 week of stability.

### Bundled
This branch also includes the watcher test-skip fix already in PR #294 (cherry-picked so the pre-push hook passes). When #294 merges first, this PR rebases trivially.

## Testing

- [x] Preview branch reachable: \`curl /rest/v1/deputies\` returns expected rows.
- [x] Schema parity verified by diff of \`pg_dump\` outputs (zero diff between prod and old-staging pre-migration).
- [x] Pre-push test suite passes locally.
- [ ] Trigger staging deployment and verify it builds + serves.
- [ ] E2E suite green against staging.
- [ ] Watcher \`sync-data\` GHA against new branch (run manually after merge).