### PR TITLE
fix(watcher): convert invariants.test.ts to it.skipIf (ADA-210)

### DIFF
--- a/apps/watcher/src/data-consistency/invariants.test.ts
+++ b/apps/watcher/src/data-consistency/invariants.test.ts
@@ -43,13 +43,16 @@ async function probeSupabase(): Promise<SupabaseClient | null> {
   return client;
 }
 
-const supabase = await probeSupabase();
-const hasSupabase = supabase !== null;
+const probedClient = await probeSupabase();
+const hasSupabase = probedClient !== null;
+// Safe to cast: every test using `supabase` is guarded by it.skipIf(!hasSupabase),
+// so the body only executes when the client is non-null.
+const supabase = probedClient as SupabaseClient;
 
 describe('Database Data Invariants', () => {
   describe('Work Score Consistency', () => {
     it.skipIf(!hasSupabase)('all active deputies should have a work_score', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputy_details')
         .select('id, name, work_score')
         .eq('is_active', true)
@@ -62,7 +65,7 @@ describe('Database Data Invariants', () => {
     it.skipIf(!hasSupabase)(
       'work_score should be between 0 and 200 (capped components allow >100)',
       async () => {
-        const { data: tooLow, error: errLow } = await supabase!
+        const { data: tooLow, error: errLow } = await supabase
           .from('deputy_stats')
           .select('deputy_id, work_score')
           .lt('work_score', 0);
@@ -70,7 +73,7 @@ describe('Database Data Invariants', () => {
         expect(errLow).toBeNull();
         expect(tooLow).toHaveLength(0);
 
-        const { data: tooHigh, error: errHigh } = await supabase!
+        const { data: tooHigh, error: errHigh } = await supabase
           .from('deputy_stats')
           .select('deputy_id, work_score')
           .gt('work_score', 200);
@@ -81,7 +84,7 @@ describe('Database Data Invariants', () => {
     );
 
     it.skipIf(!hasSupabase)('grade should match work_score thresholds', async () => {
-      const { data, error } = await supabase!.from('deputy_stats').select('work_score, grade');
+      const { data, error } = await supabase.from('deputy_stats').select('work_score, grade');
 
       expect(error).toBeNull();
       expect(data).not.toBeNull();
@@ -110,7 +113,7 @@ describe('Database Data Invariants', () => {
     it.skipIf(!hasSupabase)(
       'national_rank should be unique for all deputies with stats',
       async () => {
-        const { data, error } = await supabase!
+        const { data, error } = await supabase
           .from('deputy_stats')
           .select('national_rank')
           .not('national_rank', 'is', null);
@@ -125,7 +128,7 @@ describe('Database Data Invariants', () => {
     );
 
     it.skipIf(!hasSupabase)('national_rank should be sequential (1 to N)', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputy_stats')
         .select('national_rank')
         .not('national_rank', 'is', null)
@@ -151,7 +154,7 @@ describe('Database Data Invariants', () => {
     it.skipIf(!hasSupabase)(
       'top 10 by work_score should match top 10 by national_rank',
       async () => {
-        const { data: byScore, error: err1 } = await supabase!
+        const { data: byScore, error: err1 } = await supabase
           .from('deputy_stats')
           .select('deputy_id')
           .not('work_score', 'is', null)
@@ -160,7 +163,7 @@ describe('Database Data Invariants', () => {
 
         expect(err1).toBeNull();
 
-        const { data: byRank, error: err2 } = await supabase!
+        const { data: byRank, error: err2 } = await supabase
           .from('deputy_stats')
           .select('deputy_id')
           .not('national_rank', 'is', null)
@@ -177,7 +180,7 @@ describe('Database Data Invariants', () => {
     );
 
     it.skipIf(!hasSupabase)('district_rank should be unique within each district', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputy_details')
         .select('district_id, district_rank')
         .not('district_rank', 'is', null);
@@ -211,7 +214,7 @@ describe('Database Data Invariants', () => {
 
   describe('Count Consistency', () => {
     it.skipIf(!hasSupabase)('attendance_rate should be between 0 and 100', async () => {
-      const { data: tooLow, error: err1 } = await supabase!
+      const { data: tooLow, error: err1 } = await supabase
         .from('deputy_stats')
         .select('deputy_id, attendance_rate')
         .lt('attendance_rate', 0);
@@ -219,7 +222,7 @@ describe('Database Data Invariants', () => {
       expect(err1).toBeNull();
       expect(tooLow).toHaveLength(0);
 
-      const { data: tooHigh, error: err2 } = await supabase!
+      const { data: tooHigh, error: err2 } = await supabase
         .from('deputy_stats')
         .select('deputy_id, attendance_rate')
         .gt('attendance_rate', 100);
@@ -229,7 +232,7 @@ describe('Database Data Invariants', () => {
     });
 
     it.skipIf(!hasSupabase)('proposal_count should be non-negative', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputy_stats')
         .select('deputy_id, proposal_count')
         .lt('proposal_count', 0);
@@ -239,7 +242,7 @@ describe('Database Data Invariants', () => {
     });
 
     it.skipIf(!hasSupabase)('intervention_count should be non-negative', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputy_stats')
         .select('deputy_id, intervention_count')
         .lt('intervention_count', 0);
@@ -249,7 +252,7 @@ describe('Database Data Invariants', () => {
     });
 
     it.skipIf(!hasSupabase)('meetings_attended should not exceed meetings_total', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputy_stats')
         .select('deputy_id, meetings_attended, meetings_total');
 
@@ -268,7 +271,7 @@ describe('Database Data Invariants', () => {
 
   describe('Deputy Data Consistency', () => {
     it.skipIf(!hasSupabase)('all deputies should have a party', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputies')
         .select('id, name, party_id')
         .is('party_id', null);
@@ -281,7 +284,7 @@ describe('Database Data Invariants', () => {
     });
 
     it.skipIf(!hasSupabase)('all active deputies should have a district', async () => {
-      const { data, error } = await supabase!
+      const { data, error } = await supabase
         .from('deputies')
         .select('id, name, district_id')
         .eq('is_active', true)
@@ -291,38 +294,33 @@ describe('Database Data Invariants', () => {
       expect(data).toHaveLength(0);
     });
 
-    it.skipIf(!hasSupabase)(
-      'all deputies should have a corresponding stats record',
-      async () => {
-        // Get all deputy IDs
-        const { data: deputies, error: err1 } = await supabase!.from('deputies').select('id');
+    it.skipIf(!hasSupabase)('all deputies should have a corresponding stats record', async () => {
+      // Get all deputy IDs
+      const { data: deputies, error: err1 } = await supabase.from('deputies').select('id');
 
-        expect(err1).toBeNull();
+      expect(err1).toBeNull();
 
-        // Get all stats deputy_ids
-        const { data: stats, error: err2 } = await supabase!
-          .from('deputy_stats')
-          .select('deputy_id');
+      // Get all stats deputy_ids
+      const { data: stats, error: err2 } = await supabase.from('deputy_stats').select('deputy_id');
 
-        expect(err2).toBeNull();
+      expect(err2).toBeNull();
 
-        const deputyIds = new Set((deputies || []).map((d) => d.id));
-        const statsDeputyIds = new Set((stats || []).map((s) => s.deputy_id));
+      const deputyIds = new Set((deputies || []).map((d) => d.id));
+      const statsDeputyIds = new Set((stats || []).map((s) => s.deputy_id));
 
-        const missing = [...deputyIds].filter((id) => !statsDeputyIds.has(id));
+      const missing = [...deputyIds].filter((id) => !statsDeputyIds.has(id));
 
-        if (missing.length > 0) {
-          console.error(`${missing.length} deputies missing stats records`);
-        }
-        expect(missing).toHaveLength(0);
+      if (missing.length > 0) {
+        console.error(`${missing.length} deputies missing stats records`);
       }
-    );
+      expect(missing).toHaveLength(0);
+    });
   });
 
   describe('Cross-View Consistency', () => {
     it.skipIf(!hasSupabase)('deputy_details view should match joined data', async () => {
       // Get first 5 from view
-      const { data: viewData, error: err1 } = await supabase!
+      const { data: viewData, error: err1 } = await supabase
         .from('deputy_details')
         .select('id, work_score, grade, national_rank, party_name')
         .limit(5);

--- a/apps/watcher/src/data-consistency/invariants.test.ts
+++ b/apps/watcher/src/data-consistency/invariants.test.ts
@@ -8,43 +8,48 @@
  * Run with: SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_ROLE_KEY=... bun test invariants
  */
 
-import { beforeAll, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { type SupabaseClient, createClient } from '@supabase/supabase-js';
 import { scoreToGrade } from './helpers.js';
 
-let supabase: SupabaseClient;
-
-beforeAll(async () => {
+// Probe whether Supabase is actually reachable (not just configured).
+// Env vars can be set (e.g. from .env) while local Supabase is offline,
+// in which case these tests must be skipped (loudly), not run-and-fail
+// or — worse — silently pass with zero assertions.
+async function probeSupabase(): Promise<SupabaseClient | null> {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!url || !key) {
     console.warn('⚠️ SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set, skipping invariant tests');
-    return;
+    return null;
   }
 
   const client = createClient(url, key, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  // Env vars can be set (e.g. from .env) while local Supabase is offline.
-  // Probe reachability before exposing the client; otherwise queries below
-  // would fail with confusing assertion errors instead of skipping cleanly.
-  const { error } = await client.from('deputy_details').select('id').limit(1);
-  if (error) {
-    console.warn(`⚠️ Supabase not reachable (${error.message}), skipping invariant tests`);
-    return;
+  try {
+    const { error } = await client.from('deputy_details').select('id').limit(1);
+    if (error) {
+      console.warn(`⚠️ Supabase not reachable (${error.message}), skipping invariant tests`);
+      return null;
+    }
+  } catch (err) {
+    console.warn(`⚠️ Supabase not reachable (${(err as Error).message}), skipping invariant tests`);
+    return null;
   }
 
-  supabase = client;
-});
+  return client;
+}
+
+const supabase = await probeSupabase();
+const hasSupabase = supabase !== null;
 
 describe('Database Data Invariants', () => {
   describe('Work Score Consistency', () => {
-    it('all active deputies should have a work_score', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('all active deputies should have a work_score', async () => {
+      const { data, error } = await supabase!
         .from('deputy_details')
         .select('id, name, work_score')
         .eq('is_active', true)
@@ -54,30 +59,29 @@ describe('Database Data Invariants', () => {
       expect(data).toHaveLength(0);
     });
 
-    it('work_score should be between 0 and 200 (capped components allow >100)', async () => {
-      if (!supabase) return;
+    it.skipIf(!hasSupabase)(
+      'work_score should be between 0 and 200 (capped components allow >100)',
+      async () => {
+        const { data: tooLow, error: errLow } = await supabase!
+          .from('deputy_stats')
+          .select('deputy_id, work_score')
+          .lt('work_score', 0);
 
-      const { data: tooLow, error: errLow } = await supabase
-        .from('deputy_stats')
-        .select('deputy_id, work_score')
-        .lt('work_score', 0);
+        expect(errLow).toBeNull();
+        expect(tooLow).toHaveLength(0);
 
-      expect(errLow).toBeNull();
-      expect(tooLow).toHaveLength(0);
+        const { data: tooHigh, error: errHigh } = await supabase!
+          .from('deputy_stats')
+          .select('deputy_id, work_score')
+          .gt('work_score', 200);
 
-      const { data: tooHigh, error: errHigh } = await supabase
-        .from('deputy_stats')
-        .select('deputy_id, work_score')
-        .gt('work_score', 200);
+        expect(errHigh).toBeNull();
+        expect(tooHigh).toHaveLength(0);
+      }
+    );
 
-      expect(errHigh).toBeNull();
-      expect(tooHigh).toHaveLength(0);
-    });
-
-    it('grade should match work_score thresholds', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase.from('deputy_stats').select('work_score, grade');
+    it.skipIf(!hasSupabase)('grade should match work_score thresholds', async () => {
+      const { data, error } = await supabase!.from('deputy_stats').select('work_score, grade');
 
       expect(error).toBeNull();
       expect(data).not.toBeNull();
@@ -103,26 +107,25 @@ describe('Database Data Invariants', () => {
   });
 
   describe('Ranking Consistency', () => {
-    it('national_rank should be unique for all deputies with stats', async () => {
-      if (!supabase) return;
+    it.skipIf(!hasSupabase)(
+      'national_rank should be unique for all deputies with stats',
+      async () => {
+        const { data, error } = await supabase!
+          .from('deputy_stats')
+          .select('national_rank')
+          .not('national_rank', 'is', null);
 
-      const { data, error } = await supabase
-        .from('deputy_stats')
-        .select('national_rank')
-        .not('national_rank', 'is', null);
+        expect(error).toBeNull();
+        expect(data).not.toBeNull();
 
-      expect(error).toBeNull();
-      expect(data).not.toBeNull();
+        const ranks = (data || []).map((d) => d.national_rank);
+        const uniqueRanks = new Set(ranks);
+        expect(ranks.length).toBe(uniqueRanks.size);
+      }
+    );
 
-      const ranks = (data || []).map((d) => d.national_rank);
-      const uniqueRanks = new Set(ranks);
-      expect(ranks.length).toBe(uniqueRanks.size);
-    });
-
-    it('national_rank should be sequential (1 to N)', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('national_rank should be sequential (1 to N)', async () => {
+      const { data, error } = await supabase!
         .from('deputy_stats')
         .select('national_rank')
         .not('national_rank', 'is', null)
@@ -145,37 +148,36 @@ describe('Database Data Invariants', () => {
       expect(gaps).toHaveLength(0);
     });
 
-    it('top 10 by work_score should match top 10 by national_rank', async () => {
-      if (!supabase) return;
+    it.skipIf(!hasSupabase)(
+      'top 10 by work_score should match top 10 by national_rank',
+      async () => {
+        const { data: byScore, error: err1 } = await supabase!
+          .from('deputy_stats')
+          .select('deputy_id')
+          .not('work_score', 'is', null)
+          .order('work_score', { ascending: false })
+          .limit(10);
 
-      const { data: byScore, error: err1 } = await supabase
-        .from('deputy_stats')
-        .select('deputy_id')
-        .not('work_score', 'is', null)
-        .order('work_score', { ascending: false })
-        .limit(10);
+        expect(err1).toBeNull();
 
-      expect(err1).toBeNull();
+        const { data: byRank, error: err2 } = await supabase!
+          .from('deputy_stats')
+          .select('deputy_id')
+          .not('national_rank', 'is', null)
+          .order('national_rank', { ascending: true })
+          .limit(10);
 
-      const { data: byRank, error: err2 } = await supabase
-        .from('deputy_stats')
-        .select('deputy_id')
-        .not('national_rank', 'is', null)
-        .order('national_rank', { ascending: true })
-        .limit(10);
+        expect(err2).toBeNull();
 
-      expect(err2).toBeNull();
+        const scoreIds = (byScore || []).map((d) => d.deputy_id);
+        const rankIds = (byRank || []).map((d) => d.deputy_id);
 
-      const scoreIds = (byScore || []).map((d) => d.deputy_id);
-      const rankIds = (byRank || []).map((d) => d.deputy_id);
+        expect(scoreIds).toEqual(rankIds);
+      }
+    );
 
-      expect(scoreIds).toEqual(rankIds);
-    });
-
-    it('district_rank should be unique within each district', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('district_rank should be unique within each district', async () => {
+      const { data, error } = await supabase!
         .from('deputy_details')
         .select('district_id, district_rank')
         .not('district_rank', 'is', null);
@@ -208,10 +210,8 @@ describe('Database Data Invariants', () => {
   });
 
   describe('Count Consistency', () => {
-    it('attendance_rate should be between 0 and 100', async () => {
-      if (!supabase) return;
-
-      const { data: tooLow, error: err1 } = await supabase
+    it.skipIf(!hasSupabase)('attendance_rate should be between 0 and 100', async () => {
+      const { data: tooLow, error: err1 } = await supabase!
         .from('deputy_stats')
         .select('deputy_id, attendance_rate')
         .lt('attendance_rate', 0);
@@ -219,7 +219,7 @@ describe('Database Data Invariants', () => {
       expect(err1).toBeNull();
       expect(tooLow).toHaveLength(0);
 
-      const { data: tooHigh, error: err2 } = await supabase
+      const { data: tooHigh, error: err2 } = await supabase!
         .from('deputy_stats')
         .select('deputy_id, attendance_rate')
         .gt('attendance_rate', 100);
@@ -228,10 +228,8 @@ describe('Database Data Invariants', () => {
       expect(tooHigh).toHaveLength(0);
     });
 
-    it('proposal_count should be non-negative', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('proposal_count should be non-negative', async () => {
+      const { data, error } = await supabase!
         .from('deputy_stats')
         .select('deputy_id, proposal_count')
         .lt('proposal_count', 0);
@@ -240,10 +238,8 @@ describe('Database Data Invariants', () => {
       expect(data).toHaveLength(0);
     });
 
-    it('intervention_count should be non-negative', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('intervention_count should be non-negative', async () => {
+      const { data, error } = await supabase!
         .from('deputy_stats')
         .select('deputy_id, intervention_count')
         .lt('intervention_count', 0);
@@ -252,10 +248,8 @@ describe('Database Data Invariants', () => {
       expect(data).toHaveLength(0);
     });
 
-    it('meetings_attended should not exceed meetings_total', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('meetings_attended should not exceed meetings_total', async () => {
+      const { data, error } = await supabase!
         .from('deputy_stats')
         .select('deputy_id, meetings_attended, meetings_total');
 
@@ -273,10 +267,8 @@ describe('Database Data Invariants', () => {
   });
 
   describe('Deputy Data Consistency', () => {
-    it('all deputies should have a party', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('all deputies should have a party', async () => {
+      const { data, error } = await supabase!
         .from('deputies')
         .select('id, name, party_id')
         .is('party_id', null);
@@ -288,10 +280,8 @@ describe('Database Data Invariants', () => {
       }
     });
 
-    it('all active deputies should have a district', async () => {
-      if (!supabase) return;
-
-      const { data, error } = await supabase
+    it.skipIf(!hasSupabase)('all active deputies should have a district', async () => {
+      const { data, error } = await supabase!
         .from('deputies')
         .select('id, name, district_id')
         .eq('is_active', true)
@@ -301,37 +291,38 @@ describe('Database Data Invariants', () => {
       expect(data).toHaveLength(0);
     });
 
-    it('all deputies should have a corresponding stats record', async () => {
-      if (!supabase) return;
+    it.skipIf(!hasSupabase)(
+      'all deputies should have a corresponding stats record',
+      async () => {
+        // Get all deputy IDs
+        const { data: deputies, error: err1 } = await supabase!.from('deputies').select('id');
 
-      // Get all deputy IDs
-      const { data: deputies, error: err1 } = await supabase.from('deputies').select('id');
+        expect(err1).toBeNull();
 
-      expect(err1).toBeNull();
+        // Get all stats deputy_ids
+        const { data: stats, error: err2 } = await supabase!
+          .from('deputy_stats')
+          .select('deputy_id');
 
-      // Get all stats deputy_ids
-      const { data: stats, error: err2 } = await supabase.from('deputy_stats').select('deputy_id');
+        expect(err2).toBeNull();
 
-      expect(err2).toBeNull();
+        const deputyIds = new Set((deputies || []).map((d) => d.id));
+        const statsDeputyIds = new Set((stats || []).map((s) => s.deputy_id));
 
-      const deputyIds = new Set((deputies || []).map((d) => d.id));
-      const statsDeputyIds = new Set((stats || []).map((s) => s.deputy_id));
+        const missing = [...deputyIds].filter((id) => !statsDeputyIds.has(id));
 
-      const missing = [...deputyIds].filter((id) => !statsDeputyIds.has(id));
-
-      if (missing.length > 0) {
-        console.error(`${missing.length} deputies missing stats records`);
+        if (missing.length > 0) {
+          console.error(`${missing.length} deputies missing stats records`);
+        }
+        expect(missing).toHaveLength(0);
       }
-      expect(missing).toHaveLength(0);
-    });
+    );
   });
 
   describe('Cross-View Consistency', () => {
-    it('deputy_details view should match joined data', async () => {
-      if (!supabase) return;
-
+    it.skipIf(!hasSupabase)('deputy_details view should match joined data', async () => {
       // Get first 5 from view
-      const { data: viewData, error: err1 } = await supabase
+      const { data: viewData, error: err1 } = await supabase!
         .from('deputy_details')
         .select('id, work_score, grade, national_rank, party_name')
         .limit(5);


### PR DESCRIPTION
Closes ADA-210.

## Why
`apps/watcher/src/data-consistency/invariants.test.ts` opened every test with `if (!supabase) return;`. When Supabase is unreachable (CI without local infra, missing env vars, etc.), every test silently **passed** with zero assertions executed — green CI was validating nothing.

## What changed
- Replaced the silent `if (!supabase) return;` guard in all 15 tests with `it.skipIf(!hasSupabase)(...)`.
- Reachability is probed once at the top level (`probeSupabase()`) and exposed via `hasSupabase`, mirroring the pattern already in `apps/watcher/src/transform/legislature-detection.integration.test.ts`.
- The probe still distinguishes between "env vars missing" and "env vars present but DB unreachable" — both surface as loud `(skip)` lines instead of false passes.
- Test logic (queries, assertions) is unchanged.

## Validation
- Without env: `bun test src/data-consistency/invariants.test.ts` → `0 pass, 15 skip, 0 fail` (previously: `15 pass, 0 skip` with no assertions). Tests now correctly report as skipped.
- Lint: `bun run lint` clean.
- Pre-push hook ran the watcher suite: `72 pass, 5 skip, 0 fail, 227 expect() calls`.
- When DB is reachable, tests execute and may surface pre-existing data quality issues — those are not regressions to fix here.

## Validation Criteria
- [ ] `cd apps/watcher && unset SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY && bun test src/data-consistency/invariants.test.ts` → 15 tests show `(skip)`, none `(pass)`.
- [ ] With Supabase reachable, at least one assertion runs (`expect() calls > 0`).