### PR TITLE
fix: batched bug fixes (ADA-206, 207, 213, 214)

### DIFF
--- a/apps/watcher/src/transform/parties-colors.ts
+++ b/apps/watcher/src/transform/parties-colors.ts
@@ -1,0 +1,20 @@
+// Party colors - official or commonly used. Kept in a supabase-free module
+// so tests can import without triggering the supabase env-var check.
+
+export const PARTY_COLORS: Record<string, string> = {
+  PS: '#FF66B2', // Pink (Socialist Party)
+  PSD: '#FF6600', // Orange (Social Democratic Party)
+  CH: '#202056', // Dark blue (Chega)
+  IL: '#00ADEF', // Light blue (Liberal Initiative)
+  BE: '#C40000', // Red (Left Bloc)
+  PCP: '#C41200', // Dark red (Communist Party)
+  L: '#00AA00', // Green (Livre)
+  PAN: '#009639', // Dark green (People-Animals-Nature)
+  'CDS-PP': '#0066CC', // Blue (CDS)
+};
+
+const FALLBACK_PARTY_COLOR = '#808080';
+
+export function getPartyColor(acronym: string): string {
+  return PARTY_COLORS[acronym] || FALLBACK_PARTY_COLOR;
+}

--- a/apps/watcher/src/transform/parties.test.ts
+++ b/apps/watcher/src/transform/parties.test.ts
@@ -1,17 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-
-// Party colors - extracted from parties.ts for testing
-const PARTY_COLORS: Record<string, string> = {
-  PS: '#FF66B2',
-  PSD: '#FF6600',
-  CH: '#202056',
-  IL: '#00ADEF',
-  BE: '#C40000',
-  PCP: '#C41200',
-  L: '#00AA00',
-  PAN: '#009639',
-  'CDS-PP': '#0066CC',
-};
+import { PARTY_COLORS, getPartyColor } from './parties.js';
 
 describe('PARTY_COLORS', () => {
   it('should have colors for all major Portuguese parties', () => {
@@ -29,9 +17,7 @@ describe('PARTY_COLORS', () => {
   });
 
   it('should have distinct colors for left and right parties', () => {
-    // PS (left) should be different from PSD (right)
     expect(PARTY_COLORS.PS).not.toBe(PARTY_COLORS.PSD);
-    // BE (left) should be different from CH (right)
     expect(PARTY_COLORS.BE).not.toBe(PARTY_COLORS.CH);
   });
 
@@ -56,24 +42,19 @@ describe('PARTY_COLORS', () => {
   });
 
   it('should have green parties (L, PAN) with green colors', () => {
-    // Both should contain green (00 in the G component)
     expect(PARTY_COLORS.L).toMatch(/#00[A-F0-9]{2}00/i);
     expect(PARTY_COLORS.PAN).toMatch(/#00[A-F0-9]{4}/i);
   });
 });
 
-describe('Party color fallback', () => {
+describe('getPartyColor', () => {
   it('should return gray for unknown party', () => {
-    const getPartyColor = (acronym: string) => PARTY_COLORS[acronym] || '#808080';
-
     expect(getPartyColor('UNKNOWN')).toBe('#808080');
     expect(getPartyColor('')).toBe('#808080');
     expect(getPartyColor('XYZ')).toBe('#808080');
   });
 
   it('should return correct color for known party', () => {
-    const getPartyColor = (acronym: string) => PARTY_COLORS[acronym] || '#808080';
-
     expect(getPartyColor('PS')).toBe('#FF66B2');
     expect(getPartyColor('PSD')).toBe('#FF6600');
   });

--- a/apps/watcher/src/transform/parties.test.ts
+++ b/apps/watcher/src/transform/parties.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { PARTY_COLORS, getPartyColor } from './parties.js';
+import { PARTY_COLORS, getPartyColor } from './parties-colors.js';
 
 describe('PARTY_COLORS', () => {
   it('should have colors for all major Portuguese parties', () => {

--- a/apps/watcher/src/transform/parties.ts
+++ b/apps/watcher/src/transform/parties.ts
@@ -2,7 +2,7 @@ import { supabase } from '../supabase.js';
 import { pipelineResult } from '../utils/pipeline-result.js';
 
 // Party colors - official or commonly used
-const PARTY_COLORS: Record<string, string> = {
+export const PARTY_COLORS: Record<string, string> = {
   PS: '#FF66B2', // Pink (Socialist Party)
   PSD: '#FF6600', // Orange (Social Democratic Party)
   CH: '#202056', // Dark blue (Chega)
@@ -13,6 +13,12 @@ const PARTY_COLORS: Record<string, string> = {
   PAN: '#009639', // Dark green (People-Animals-Nature)
   'CDS-PP': '#0066CC', // Blue (CDS)
 };
+
+const FALLBACK_PARTY_COLOR = '#808080';
+
+export function getPartyColor(acronym: string): string {
+  return PARTY_COLORS[acronym] || FALLBACK_PARTY_COLOR;
+}
 
 interface ParliamentGrupoParlamentar {
   sigla: string;
@@ -33,7 +39,7 @@ export async function transformParties(
       external_id: gp.sigla, // Use acronym as external_id (TEXT)
       acronym: gp.sigla,
       name: gp.nome,
-      color: PARTY_COLORS[gp.sigla] || '#808080',
+      color: getPartyColor(gp.sigla),
     };
 
     // Upsert by external_id (which is unique in the schema)

--- a/apps/watcher/src/transform/parties.ts
+++ b/apps/watcher/src/transform/parties.ts
@@ -1,24 +1,8 @@
 import { supabase } from '../supabase.js';
 import { pipelineResult } from '../utils/pipeline-result.js';
+import { getPartyColor } from './parties-colors.js';
 
-// Party colors - official or commonly used
-export const PARTY_COLORS: Record<string, string> = {
-  PS: '#FF66B2', // Pink (Socialist Party)
-  PSD: '#FF6600', // Orange (Social Democratic Party)
-  CH: '#202056', // Dark blue (Chega)
-  IL: '#00ADEF', // Light blue (Liberal Initiative)
-  BE: '#C40000', // Red (Left Bloc)
-  PCP: '#C41200', // Dark red (Communist Party)
-  L: '#00AA00', // Green (Livre)
-  PAN: '#009639', // Dark green (People-Animals-Nature)
-  'CDS-PP': '#0066CC', // Blue (CDS)
-};
-
-const FALLBACK_PARTY_COLOR = '#808080';
-
-export function getPartyColor(acronym: string): string {
-  return PARTY_COLORS[acronym] || FALLBACK_PARTY_COLOR;
-}
+export { PARTY_COLORS, getPartyColor } from './parties-colors.js';
 
 interface ParliamentGrupoParlamentar {
   sigla: string;

--- a/apps/web/e2e/leaderboard.spec.ts
+++ b/apps/web/e2e/leaderboard.spec.ts
@@ -82,27 +82,22 @@ test.describe('Leaderboard Page', () => {
     expect(suspendedCount).toBe(0);
   });
 
-  // Issue #97: Legislature format should be "XVII" not "XVIIª"
+  // Issue #97 / ADA-214: Legislature format should be roman numerals, no ordinal suffix
   // @see https://github.com/bcamarneiro/adamastor/issues/97
-  test('legislature badge should display "XVII Legislatura" without ordinal suffix', async ({
+  test('legislature badge should display roman numeral without ordinal suffix', async ({
     page,
   }) => {
     await page.goto('/ranking');
     await page.waitForLoadState('networkidle');
 
-    // Find the legislature badge - it should show "XVII Legislatura"
-    const legislatureBadge = page.getByText(/XVII Legislatura/i);
+    // Match any roman-numeral legislature followed by "Legislatura"
+    const legislatureBadge = page.getByText(/[IVXLCDM]+\s+Legislatura/i);
 
-    if ((await legislatureBadge.count()) > 0) {
-      const badgeText = await legislatureBadge.first().textContent();
+    // Fail if no legislature badge appears at all — silent-pass guard
+    await expect(legislatureBadge.first()).toBeVisible();
 
-      // Verify it does NOT contain the ordinal suffix "ª"
-      expect(badgeText).not.toContain('ª');
-      expect(badgeText).not.toContain('XVIIª');
-
-      // Verify it shows the correct format
-      expect(badgeText).toContain('XVII Legislatura');
-    }
+    const badgeText = await legislatureBadge.first().textContent();
+    expect(badgeText).not.toContain('ª');
   });
 
   // Issue #76: Explain tiebreaker criteria in rankings

--- a/apps/web/src/pages/InitiativesPage/InitiativeList/InitiativeList.test.tsx
+++ b/apps/web/src/pages/InitiativesPage/InitiativeList/InitiativeList.test.tsx
@@ -339,7 +339,7 @@ describe('InitiativeList', () => {
       render(<InitiativeList />);
 
       // The page title should still be visible during loading
-      expect(screen.getByRole('heading', { name: 'Initiatives List' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Lista de Iniciativas' })).toBeTruthy();
     });
 
     it('should still display filter controls when loading', () => {
@@ -487,7 +487,7 @@ describe('InitiativeList', () => {
       render(<InitiativeList />);
 
       // The component returns early with error, so page header should not render
-      expect(screen.queryByRole('heading', { name: 'Initiatives List' })).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Lista de Iniciativas' })).toBeNull();
     });
 
     it('should NOT display filter controls when in error state', () => {
@@ -609,7 +609,7 @@ describe('InitiativeList', () => {
 
       render(<InitiativeList />);
 
-      expect(screen.getByRole('heading', { name: 'Initiatives List' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Lista de Iniciativas' })).toBeTruthy();
       expect(screen.getByPlaceholderText('Search initiatives...')).toBeTruthy();
       expect(screen.getByLabelText('Filter by phase')).toBeTruthy();
     });
@@ -1292,7 +1292,7 @@ describe('InitiativeList', () => {
 
       render(<InitiativeList />);
 
-      expect(screen.getByRole('heading', { name: 'Initiatives List' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Lista de Iniciativas' })).toBeTruthy();
     });
   });
 });

--- a/apps/web/src/pages/InitiativesPage/InitiativeList/InitiativeList.tsx
+++ b/apps/web/src/pages/InitiativesPage/InitiativeList/InitiativeList.tsx
@@ -173,7 +173,7 @@ const InitiativeList = () => {
   return (
     <div className="w-full h-full flex flex-col p-5 overflow-hidden">
       <div className="flex-none">
-        <h1 className="text-2xl font-bold mb-4">Initiatives List</h1>
+        <h1 className="text-2xl font-bold mb-4">Lista de Iniciativas</h1>
 
         <Accordion.Root type="single" collapsible className="mb-6">
           <Accordion.Item value="details" className="border rounded-lg overflow-hidden">

--- a/apps/web/src/pages/LeaderboardPage/FullRankingsPage.tsx
+++ b/apps/web/src/pages/LeaderboardPage/FullRankingsPage.tsx
@@ -43,7 +43,7 @@ async function fetchDistricts(): Promise<District[]> {
 
 async function fetchAggregateStats() {
   const { data, error } = await supabase
-    .from('deputy_detail')
+    .from('deputy_details')
     .select('work_score, grade')
     .not('work_score', 'is', null);
 


### PR DESCRIPTION
## Summary

Four small, independent fixes from the production audit, bundled because each is 1-3 lines and they touch separate files.

| Issue | Severity | Change |
|-------|----------|--------|
| [ADA-206](https://linear.app/adamastor/issue/ADA-206) | 🔴 Urgent | Fix \`deputy_detail\` → \`deputy_details\` typo in FullRankingsPage |
| [ADA-207](https://linear.app/adamastor/issue/ADA-207) | 🟠 High | Translate \"Initiatives List\" h1 → \"Lista de Iniciativas\" |
| [ADA-213](https://linear.app/adamastor/issue/ADA-213) | ⚪ Low | parties.test.ts: import \`PARTY_COLORS\` instead of redefining it |
| [ADA-214](https://linear.app/adamastor/issue/ADA-214) | ⚪ Low | leaderboard e2e: roman-numeral regex instead of hardcoded \"XVII\" |

## Notes & follow-ups

- **ADA-207 partial:** \`InitiativeList.tsx\` still has more English copy (\"Statistics Overview\", \"Total Initiatives\", \"All Phases\", \"Search initiatives...\"). The Linear issue specifically scoped only the h1; left the rest for a follow-up issue.
- **ADA-213:** added a small refactor — extracted \`getPartyColor()\` helper from the inline \`PARTY_COLORS[acronym] || '#808080'\` pattern in \`transformParties\`. Same behavior, but now the production fallback path is exported and testable.
- **ADA-214 partial:** The Linear issue also flagged \`expect(rank).toBeLessThanOrEqual(230)\` as data drift. I left that — 230 is Portugal's constitutional cap on parliament size (Article 148, Constituição da República Portuguesa), not a data value that drifts. If we wanted to be defensive against test-double-magic-number issues, fetching from API would be overkill here.
- **ADA-214 fix bonus:** the previous test had \`if ((await badge.count()) > 0)\` — silently passing when no badge was found. Replaced with \`await expect(...).toBeVisible()\` so badge-removal regressions surface.

## Testing

- [x] \`bun test\` passes locally for the watcher suite
- [x] Pre-push hook green
- [ ] e2e against staging on this PR
- [ ] Manual: open /ranking/completo and confirm aggregate stats render with no console errors