### PR TITLE
fix(web): restore Portuguese diacritics on deputy report card (ADA-208)

### DIFF
--- a/apps/web/src/components/ReportCard/ReportCardDetail.test.tsx
+++ b/apps/web/src/components/ReportCard/ReportCardDetail.test.tsx
@@ -272,7 +272,7 @@ describe('ReportCardDetail', () => {
 
         renderWithRouter(<ReportCardDetail deputy={deputy} averages={mockAverages} />);
 
-        expect(screen.getByRole('heading', { name: /Classificacao/i })).toBeTruthy();
+        expect(screen.getByRole('heading', { name: /Classificação/i })).toBeTruthy();
       });
 
       it('should render GradeCircle with deputy grade', () => {
@@ -293,12 +293,12 @@ describe('ReportCardDetail', () => {
         expect(screen.getByText('85 pts')).toBeTruthy();
       });
 
-      it('should render GradeCircle with "Pontuacao" label', () => {
+      it('should render GradeCircle with "Pontuação" label', () => {
         const deputy = createMockDeputyDetail();
 
         renderWithRouter(<ReportCardDetail deputy={deputy} averages={mockAverages} />);
 
-        expect(screen.getByText('Pontuacao')).toBeTruthy();
+        expect(screen.getByText('Pontuação')).toBeTruthy();
       });
     });
 

--- a/apps/web/src/components/ReportCard/ReportCardDetail.tsx
+++ b/apps/web/src/components/ReportCard/ReportCardDetail.tsx
@@ -136,7 +136,7 @@ export function ReportCardDetail({ deputy, averages, extendedInfo }: ReportCardD
       <div className="p-6 border-b border-neutral-5">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-neutral-12">Classificacao</h2>
+            <h2 className="text-lg font-semibold text-neutral-12">Classificação</h2>
             <div className="flex items-center gap-4 mt-2 text-sm text-neutral-11">
               <span className="flex items-center gap-1" data-testid="national-rank">
                 <span className="font-medium">#{deputy.national_rank}</span> nacional
@@ -148,7 +148,7 @@ export function ReportCardDetail({ deputy, averages, extendedInfo }: ReportCardD
           </div>
           <div className="flex flex-col items-center">
             <GradeCircle grade={deputy.grade} score={deputy.work_score} size="lg" />
-            <span className="text-xs text-neutral-9 mt-1">Pontuacao</span>
+            <span className="text-xs text-neutral-9 mt-1">Pontuação</span>
           </div>
         </div>
         <ClassificationPanel


### PR DESCRIPTION
Closes ADA-208

## What
On the deputy detail page (e.g. `/deputado/<id>`), the report-card section rendered Portuguese labels stripped of diacritics:

- "Classificacao" → should be "Classificação"
- "Pontuacao" → should be "Pontuação"

## Where
The labels were hardcoded as ASCII strings directly in `apps/web/src/components/ReportCard/ReportCardDetail.tsx` (the grade section heading on line 139 and the score label under the GradeCircle on line 151). This was not a transliteration step or a runtime normalization — just literal ASCII text in the JSX.

The deputy's full name and other dynamic fields above the report-card render from API data, which is why those displayed accents correctly while the static labels did not.

## "Atividade Parlamentar" finding
Already correct in source. The truncated form ("Atividade Parlamenta…") seen in the bug report is UI text-overflow ellipsis, not a missing letter. No change made.

## "Tecnico Adminiatrativo" typo audit
**Zero occurrences** of the literal string "Adminiatrativo" anywhere in the repository (searched `.ts`, `.tsx`, `.json`, `.sql`, `.md`, `.yml`). The "Tecnico Adminiatrativo" text rendered on the page comes from `deputy.profession`, which is sourced from the upstream parliament data and rendered as-is in the header badge. Fixing that requires a data correction (database update or scraper normalization) and is out of scope for this code-only PR — flagged as a follow-up.

## Follow-ups (not addressed here, deliberately scoped out)
There are several other ASCII-Portuguese labels in the same component and elsewhere on the site (e.g. "Cargos e Funcoes", "Historico Partidario", "Historico de Situacao", "Presenca em Plenario", "Intervencoes em debates", "sessoes", and the "Pontuacao Media" / "Atividade Parlamentar" headings on other pages). These match the same pattern but were not in the bug report and were left untouched to keep this PR minimal-scope.

## Testing
- [x] Unit tests updated (`ReportCardDetail.test.tsx`) — assertions for "Pontuacao" and "Classificacao" updated to match the corrected diacritics.
- [x] `bun run vitest run src/components/ReportCard/ReportCardDetail.test.tsx` — 90/90 passing.
- [x] Pre-push hook ran the full web test suite — all green.

## Validation Criteria
- [ ] Go to `/deputado/<any deputy id>` on a preview deployment.
- [ ] Verify the grade section heading reads **"Classificação"** (not "Classificacao").
- [ ] Verify the small label under the grade circle reads **"Pontuação"** (not "Pontuacao").
- [ ] Verify the deputy's name above the card still renders correctly (regression check).