### PR TITLE
fix(web): set page titles on /parliament, /initiatives, 404 (ADA-209)

### DIFF
--- a/apps/web/src/components/FourOFour/FourOFour.tsx
+++ b/apps/web/src/components/FourOFour/FourOFour.tsx
@@ -1,8 +1,13 @@
+import { SEO, SEO_CONFIGS } from '@/components/SEO';
+
 const FourOFour: React.FC<{ label?: string }> = ({ label = '404' }) => (
-  <div className="h-full w-full flex flex-col items-center justify-center">
-    <img src="/404-gandalf.gif" alt={label} />
-    <p>{label}</p>
-  </div>
+  <>
+    <SEO {...SEO_CONFIGS.notFound} noindex />
+    <div className="h-full w-full flex flex-col items-center justify-center">
+      <img src="/404-gandalf.gif" alt={label} />
+      <p>{label}</p>
+    </div>
+  </>
 );
 
 export default FourOFour;

--- a/apps/web/src/components/SEO/SEO.tsx
+++ b/apps/web/src/components/SEO/SEO.tsx
@@ -144,6 +144,20 @@ export const SEO_CONFIGS = {
     description:
       "Como o Debaixo d'olho protege a tua privacidade. Explicação sobre que dados recolhemos, como os utilizamos, e os teus direitos.",
   },
+  parliament: {
+    title: 'Parlamento',
+    description:
+      'Acompanha a atividade do Parlamento português. Vê sessões, votações e o trabalho dos deputados.',
+  },
+  initiatives: {
+    title: 'Iniciativas',
+    description:
+      'Consulta as iniciativas legislativas apresentadas no Parlamento português. Acompanha propostas, projetos de lei e o estado de cada iniciativa.',
+  },
+  notFound: {
+    title: 'Página não encontrada',
+    description: 'A página que procuras não existe ou foi movida.',
+  },
 } as const;
 
 /**

--- a/apps/web/src/pages/InitiativesPage/InitiativesPage.tsx
+++ b/apps/web/src/pages/InitiativesPage/InitiativesPage.tsx
@@ -1,12 +1,16 @@
+import { SEO, SEO_CONFIGS } from '@/components/SEO';
 import PageLayout from '@/components/ui/Layout/PageLayout';
 import { Outlet } from 'react-router-dom';
 import './InitiativesPage.css';
 
 const InitiativesPage: React.FC = () => {
   return (
-    <PageLayout title="Initiatives" path="/initiatives">
-      <Outlet />
-    </PageLayout>
+    <>
+      <SEO {...SEO_CONFIGS.initiatives} url="/initiatives" />
+      <PageLayout title="Initiatives" path="/initiatives">
+        <Outlet />
+      </PageLayout>
+    </>
   );
 };
 

--- a/apps/web/src/pages/ParliamentPage/ParliamentPage.tsx
+++ b/apps/web/src/pages/ParliamentPage/ParliamentPage.tsx
@@ -1,11 +1,15 @@
+import { SEO, SEO_CONFIGS } from '@/components/SEO';
 import PageLayout from '@/components/ui/Layout/PageLayout';
 import { Outlet } from 'react-router-dom';
 
 const ParliamentPage: React.FC = () => {
   return (
-    <PageLayout title="Parlamento" path="/parliament">
-      <Outlet />
-    </PageLayout>
+    <>
+      <SEO {...SEO_CONFIGS.parliament} url="/parliament" />
+      <PageLayout title="Parlamento" path="/parliament">
+        <Outlet />
+      </PageLayout>
+    </>
   );
 };
 


### PR DESCRIPTION
Closes ADA-209

## What
Three routes were rendering the default landing-page document title (`Debaixo d'olho | Acompanha o Teu Deputado`) instead of route-specific titles:
- `/parliament` -> now `Parlamento | Debaixo d'olho`
- `/initiatives` -> now `Iniciativas | Debaixo d'olho`
- Unmatched routes (404) -> now `Página não encontrada | Debaixo d'olho` (with `noindex`)

## Why
Page titles improve UX (browser tabs, history, share previews) and SEO. The three offending pages were missing the existing `<SEO />` component that the rest of the app uses.

## How
Reused the existing `react-helmet-async`-based `SEO` component pattern (e.g. `apps/web/src/pages/AboutPage/AboutPage.tsx` uses `<SEO {...SEO_CONFIGS.about} url="/about" />`). Added three new entries to `SEO_CONFIGS` (`parliament`, `initiatives`, `notFound`) and rendered `<SEO />` in:
- `apps/web/src/pages/ParliamentPage/ParliamentPage.tsx`
- `apps/web/src/pages/InitiativesPage/InitiativesPage.tsx`
- `apps/web/src/components/FourOFour/FourOFour.tsx` (with `noindex`)

No new dependencies. No refactor of surrounding code.

## Out of scope
The issue mentions that the SPA returns HTTP 200 for unknown routes. That is a Vercel rewrite/SPA-fallback concern, not a title concern. Tracked separately.

## Validation
- [ ] Visit `/parliament` -> tab title is `Parlamento | Debaixo d'olho`
- [ ] Visit `/initiatives` -> tab title is `Iniciativas | Debaixo d'olho`
- [ ] Visit `/this-route-does-not-exist` -> tab title is `Página não encontrada | Debaixo d'olho`
- [ ] Visit `/ranking` and `/sobre` still show their existing titles (regression check)

## Testing
- [x] Pre-push hook (typecheck + watcher tests) passed locally
- [x] Existing test suite unaffected (one pre-existing unrelated failure on `ParliamentList.test.tsx` due to missing `class-variance-authority` import — exists on staging, not introduced by this PR)