### PR TITLE
test(watcher): add unit tests for 6 untested transforms (ADA-212)

### DIFF
--- a/apps/watcher/src/transform/activities-helpers.ts
+++ b/apps/watcher/src/transform/activities-helpers.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure helpers for the activities transform.
+ *
+ * Kept separate from `activities.ts` so they can be unit-tested without
+ * importing `supabase.ts` (which throws at import time when env vars are
+ * missing).
+ */
+
+export interface ParliamentDebate {
+  DebateId: string;
+  Assunto: string;
+  AutoresDeputados: string | null;
+  AutoresGP: string | null;
+  DataDebate: string;
+  Intervencoes: string[];
+  TipoDebateDesig: string;
+}
+
+export interface ParliamentAtividades {
+  Debates: ParliamentDebate[];
+}
+
+/**
+ * Parse "Deputy Name (PARTY)" author strings emitted by the Parliament API.
+ * Returns null if the input is null/empty or does not match the expected shape.
+ */
+export function extractDeputyFromAuthor(
+  authorString: string | null
+): { name: string; party: string } | null {
+  if (!authorString) return null;
+
+  // Format: "Deputy Name (PARTY)" — party may contain a hyphen (e.g. "CDS-PP")
+  const match = authorString.match(/^(.+?)\s*\((\w+(?:-\w+)?)\)$/);
+  if (match) {
+    const name = match[1];
+    const party = match[2];
+    if (name && party) {
+      return { name: name.trim(), party };
+    }
+  }
+  return null;
+}
+
+/**
+ * Count intervention totals per party from a list of debates.
+ *
+ * Attribution rules (mirrors production behaviour):
+ *  - If a debate has `AutoresGP` (party authors), all its interventions are
+ *    split among each listed party.
+ *  - Otherwise, if a debate has a `AutoresDeputados` string we recognise,
+ *    interventions are attributed to that deputy's party.
+ *  - Debates with no recognisable authorship contribute nothing.
+ */
+export function countInterventionsByParty(atividades: ParliamentAtividades): Map<string, number> {
+  const counts = new Map<string, number>();
+  const debates = atividades.Debates || [];
+
+  for (const debate of debates) {
+    const interventionCount = debate.Intervencoes?.length || 0;
+
+    if (debate.AutoresGP) {
+      const parties = debate.AutoresGP.split(',').map((p) => p.trim());
+      for (const party of parties) {
+        counts.set(party, (counts.get(party) || 0) + interventionCount);
+      }
+    } else if (debate.AutoresDeputados) {
+      const author = extractDeputyFromAuthor(debate.AutoresDeputados);
+      if (author) {
+        counts.set(author.party, (counts.get(author.party) || 0) + interventionCount);
+      }
+    }
+  }
+
+  return counts;
+}

--- a/apps/watcher/src/transform/activities.test.ts
+++ b/apps/watcher/src/transform/activities.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test';
+import { countInterventionsByParty, extractDeputyFromAuthor } from './activities-helpers.js';
+
+describe('extractDeputyFromAuthor', () => {
+  it('parses real-shape "Name (PARTY)" string including hyphenated parties', () => {
+    expect(extractDeputyFromAuthor('Maria Silva (PS)')).toEqual({
+      name: 'Maria Silva',
+      party: 'PS',
+    });
+    expect(extractDeputyFromAuthor('João Pereira (CDS-PP)')).toEqual({
+      name: 'João Pereira',
+      party: 'CDS-PP',
+    });
+  });
+
+  it('returns null for null, empty, or unparseable inputs', () => {
+    expect(extractDeputyFromAuthor(null)).toBeNull();
+    expect(extractDeputyFromAuthor('')).toBeNull();
+    expect(extractDeputyFromAuthor('No party suffix')).toBeNull();
+  });
+});
+
+describe('countInterventionsByParty', () => {
+  it('attributes interventions to party authors and falls back to deputy parsing', () => {
+    const counts = countInterventionsByParty({
+      Debates: [
+        // Party-authored debate: 3 interventions split across two parties.
+        {
+          DebateId: '1',
+          Assunto: 'Debate A',
+          AutoresGP: 'PS, CDS-PP',
+          AutoresDeputados: null,
+          DataDebate: '2024-01-01',
+          Intervencoes: ['i1', 'i2', 'i3'],
+          TipoDebateDesig: 'Plenário',
+        },
+        // Deputy-authored debate: 2 interventions attributed to PSD.
+        {
+          DebateId: '2',
+          Assunto: 'Debate B',
+          AutoresGP: null,
+          AutoresDeputados: 'Ana Costa (PSD)',
+          DataDebate: '2024-01-02',
+          Intervencoes: ['i4', 'i5'],
+          TipoDebateDesig: 'Plenário',
+        },
+        // Second PS debate to confirm accumulation.
+        {
+          DebateId: '3',
+          Assunto: 'Debate C',
+          AutoresGP: 'PS',
+          AutoresDeputados: null,
+          DataDebate: '2024-01-03',
+          Intervencoes: ['i6'],
+          TipoDebateDesig: 'Plenário',
+        },
+      ],
+    });
+
+    expect(counts.get('PS')).toBe(4); // 3 + 1
+    expect(counts.get('CDS-PP')).toBe(3);
+    expect(counts.get('PSD')).toBe(2);
+  });
+
+  it('handles missing/null authors and empty Debates without crashing', () => {
+    expect(countInterventionsByParty({ Debates: [] }).size).toBe(0);
+
+    const counts = countInterventionsByParty({
+      Debates: [
+        {
+          DebateId: '1',
+          Assunto: 'Orphan',
+          AutoresGP: null,
+          AutoresDeputados: null,
+          DataDebate: '2024-01-01',
+          Intervencoes: ['x', 'y'],
+          TipoDebateDesig: 'Plenário',
+        },
+      ],
+    });
+    // No authorship -> nothing attributed.
+    expect(counts.size).toBe(0);
+  });
+});

--- a/apps/watcher/src/transform/activities.ts
+++ b/apps/watcher/src/transform/activities.ts
@@ -1,35 +1,7 @@
 import { supabase } from '../supabase.js';
+import { type ParliamentAtividades, countInterventionsByParty } from './activities-helpers.js';
 
-interface ParliamentDebate {
-  DebateId: string;
-  Assunto: string;
-  AutoresDeputados: string | null;
-  AutoresGP: string | null;
-  DataDebate: string;
-  Intervencoes: string[];
-  TipoDebateDesig: string;
-}
-
-interface ParliamentAtividades {
-  Debates: ParliamentDebate[];
-}
-
-function extractDeputyFromAuthor(
-  authorString: string | null
-): { name: string; party: string } | null {
-  if (!authorString) return null;
-
-  // Format: "Deputy Name (PARTY)"
-  const match = authorString.match(/^(.+?)\s*\((\w+(?:-\w+)?)\)$/);
-  if (match) {
-    const name = match[1];
-    const party = match[2];
-    if (name && party) {
-      return { name: name.trim(), party };
-    }
-  }
-  return null;
-}
+export type { ParliamentAtividades } from './activities-helpers.js';
 
 export async function countInterventions(
   atividades: ParliamentAtividades,
@@ -37,32 +9,10 @@ export async function countInterventions(
 ): Promise<Map<string, number>> {
   console.log('📦 Counting interventions from debates...');
 
-  const interventionCounts = new Map<string, number>(); // party_acronym -> count
   const debates = atividades.Debates || [];
-
   console.log(`  Found ${debates.length} debates`);
 
-  for (const debate of debates) {
-    // Count interventions per debate (array of intervention IDs)
-    const interventionCount = debate.Intervencoes?.length || 0;
-
-    // Try to attribute to party from authors
-    if (debate.AutoresGP) {
-      // If it's a party debate, attribute all interventions to that party
-      const parties = debate.AutoresGP.split(',').map((p) => p.trim());
-      for (const party of parties) {
-        const current = interventionCounts.get(party) || 0;
-        interventionCounts.set(party, current + interventionCount);
-      }
-    } else if (debate.AutoresDeputados) {
-      // Try to extract party from deputy author
-      const author = extractDeputyFromAuthor(debate.AutoresDeputados);
-      if (author) {
-        const current = interventionCounts.get(author.party) || 0;
-        interventionCounts.set(author.party, current + interventionCount);
-      }
-    }
-  }
+  const interventionCounts = countInterventionsByParty(atividades);
 
   console.log('✅ Intervention counts by party:');
   for (const [party, count] of interventionCounts) {

--- a/apps/watcher/src/transform/attendance-helpers.ts
+++ b/apps/watcher/src/transform/attendance-helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helpers for the attendance transform.
+ *
+ * Extracted from `attendance.ts` so the name-matching logic can be
+ * unit-tested without importing supabase.
+ */
+
+/**
+ * Lowercase, strip diacritics and non-letters from a name.
+ *
+ * Used for fuzzy matching deputy names returned by different Parliament
+ * endpoints (which inconsistently include accents and punctuation).
+ */
+export function normalizeName(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .normalize('NFD')
+      // biome-ignore lint/suspicious/noMisleadingCharacterClass: Unicode range for diacritical marks is intentional
+      .replace(/[̀-ͯ]/g, '') // Remove accents
+      .replace(/[^a-z\s]/g, '') // Remove non-letters
+      .trim()
+  );
+}
+
+/**
+ * Fuzzy-match two deputy names.
+ *
+ * Returns true when:
+ *  - normalised forms are identical, OR
+ *  - one normalised form fully contains the other (covers full-name vs
+ *    short-name), OR
+ *  - at least 70% of words from the shorter name appear in the longer one.
+ */
+export function namesMatch(name1: string, name2: string): boolean {
+  const n1 = normalizeName(name1);
+  const n2 = normalizeName(name2);
+
+  if (n1 === n2) return true;
+
+  if (n1.includes(n2) || n2.includes(n1)) return true;
+
+  const words1 = n1.split(/\s+/);
+  const words2 = n2.split(/\s+/);
+  const shorter = words1.length <= words2.length ? words1 : words2;
+  const longer = words1.length > words2.length ? words1 : words2;
+
+  const matchingWords = shorter.filter((w) => longer.some((lw) => lw === w || lw.includes(w)));
+  return matchingWords.length >= Math.ceil(shorter.length * 0.7);
+}

--- a/apps/watcher/src/transform/attendance.test.ts
+++ b/apps/watcher/src/transform/attendance.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { namesMatch, normalizeName } from './attendance-helpers.js';
+
+describe('normalizeName', () => {
+  it('lowercases, strips diacritics and punctuation, and trims', () => {
+    expect(normalizeName('  José Manuel Carvalho-Silva  ')).toBe('jose manuel carvalhosilva');
+    expect(normalizeName('Maria João Pereira d’Almeida')).toBe('maria joao pereira dalmeida');
+  });
+});
+
+describe('namesMatch', () => {
+  it('matches full name vs short name and ignores diacritics', () => {
+    // Direct accent-insensitive equality
+    expect(namesMatch('José Silva', 'Jose Silva')).toBe(true);
+    // Short name (substring) vs full name -> contains-match.
+    expect(namesMatch('Maria Pereira', 'Maria João Pereira de Sousa')).toBe(true);
+    // Different deputies should NOT match.
+    expect(namesMatch('Ana Costa', 'Pedro Marques')).toBe(false);
+  });
+
+  it('handles edge inputs (single token, hyphens, empty space)', () => {
+    // Single shared token in shorter name (1/1 = 100%) → matches.
+    expect(namesMatch('Silva', 'João Silva Costa')).toBe(true);
+    // No overlap → no match.
+    expect(namesMatch('Silva', 'Pereira')).toBe(false);
+    // Hyphenated surnames normalise the same way as joined ones.
+    expect(namesMatch('Ana Carvalho-Silva', 'Ana CarvalhoSilva')).toBe(true);
+  });
+});

--- a/apps/watcher/src/transform/attendance.ts
+++ b/apps/watcher/src/transform/attendance.ts
@@ -11,50 +11,13 @@
 import { CURRENT_LEGISLATURE } from '../config.js';
 import type { AttendanceRecord, PlenaryMeeting } from '../scrapers/attendance.js';
 import { supabase } from '../supabase.js';
+import { namesMatch } from './attendance-helpers.js';
 
 interface DeputyMatch {
   id: string;
   name: string;
   short_name: string | null;
   biography_id: number | null;
-}
-
-/**
- * Normalize name for fuzzy matching
- */
-function normalizeName(name: string): string {
-  return (
-    name
-      .toLowerCase()
-      .normalize('NFD')
-      // biome-ignore lint/suspicious/noMisleadingCharacterClass: Unicode range for diacritical marks is intentional
-      .replace(/[\u0300-\u036f]/g, '') // Remove accents
-      .replace(/[^a-z\s]/g, '') // Remove non-letters
-      .trim()
-  );
-}
-
-/**
- * Check if two names match (fuzzy)
- */
-function namesMatch(name1: string, name2: string): boolean {
-  const n1 = normalizeName(name1);
-  const n2 = normalizeName(name2);
-
-  // Exact match
-  if (n1 === n2) return true;
-
-  // Check if one contains the other (for short_name vs full name)
-  if (n1.includes(n2) || n2.includes(n1)) return true;
-
-  // Check if all words from shorter name are in longer name
-  const words1 = n1.split(/\s+/);
-  const words2 = n2.split(/\s+/);
-  const shorter = words1.length <= words2.length ? words1 : words2;
-  const longer = words1.length > words2.length ? words1 : words2;
-
-  const matchingWords = shorter.filter((w) => longer.some((lw) => lw === w || lw.includes(w)));
-  return matchingWords.length >= Math.ceil(shorter.length * 0.7);
 }
 
 /**

--- a/apps/watcher/src/transform/biography-helpers.ts
+++ b/apps/watcher/src/transform/biography-helpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure helpers for the biography transform.
+ *
+ * Extracted from `biography.ts` so the TTL-staleness logic and the
+ * biography-data summariser can be unit-tested without importing supabase.
+ */
+
+/** Number of days before a biography is considered stale and needs re-scraping */
+export const BIOGRAPHY_TTL_DAYS = 7;
+
+/**
+ * Compute the ISO-8601 cutoff before which a biography counts as stale.
+ *
+ * `biography.ts` uses `new Date()` for the reference point; we accept it as
+ * a parameter so callers can be deterministic in tests.
+ */
+export function getStaleCutoffIso(
+  now: Date = new Date(),
+  ttlDays: number = BIOGRAPHY_TTL_DAYS
+): string {
+  const stale = new Date(now);
+  stale.setDate(stale.getDate() - ttlDays);
+  return stale.toISOString();
+}
+
+/**
+ * Decide whether a deputy's biography needs re-scraping.
+ *
+ * Mirrors the predicate inside `getDeputiesWithBiographyId`:
+ *  - true if the biography has never been scraped (`scrapedAt` is null)
+ *  - true if `scrapedAt` is strictly older than the cutoff
+ *  - false otherwise
+ */
+export function isBiographyStale(
+  scrapedAtIso: string | null | undefined,
+  cutoffIso: string
+): boolean {
+  if (!scrapedAtIso) return true;
+  return scrapedAtIso < cutoffIso;
+}
+
+/**
+ * Shape of biography data scraped per deputy. Mirrors `BiographyData` in the
+ * scraper module but redeclared here to keep this helper free of imports.
+ */
+export interface BiographyLike {
+  birthDate?: string | null;
+  profession?: string | null;
+  education?: string | null;
+}
+
+/**
+ * Roll up a list of scraped biographies into the counters reported by the
+ * transform's summary block.
+ */
+export function summarizeBiographies(bios: BiographyLike[]): {
+  scraped: number;
+  withBirthDate: number;
+  withProfession: number;
+  withEducation: number;
+} {
+  let withBirthDate = 0;
+  let withProfession = 0;
+  let withEducation = 0;
+
+  for (const bio of bios) {
+    if (bio.birthDate) withBirthDate++;
+    if (bio.profession) withProfession++;
+    if (bio.education) withEducation++;
+  }
+
+  return {
+    scraped: bios.length,
+    withBirthDate,
+    withProfession,
+    withEducation,
+  };
+}

--- a/apps/watcher/src/transform/biography.test.ts
+++ b/apps/watcher/src/transform/biography.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  BIOGRAPHY_TTL_DAYS,
+  getStaleCutoffIso,
+  isBiographyStale,
+  summarizeBiographies,
+} from './biography-helpers.js';
+
+describe('biography TTL helpers', () => {
+  it('treats biographies older than the TTL as stale, fresh ones as not', () => {
+    const now = new Date('2024-06-15T12:00:00.000Z');
+    const cutoff = getStaleCutoffIso(now, BIOGRAPHY_TTL_DAYS);
+
+    // Cutoff lands exactly TTL days before `now`.
+    expect(cutoff).toBe('2024-06-08T12:00:00.000Z');
+
+    // Older than cutoff → stale.
+    expect(isBiographyStale('2024-06-01T00:00:00.000Z', cutoff)).toBe(true);
+    // Strictly newer than cutoff → not stale.
+    expect(isBiographyStale('2024-06-14T00:00:00.000Z', cutoff)).toBe(false);
+  });
+
+  it('treats null/undefined scraped_at as needing scraping', () => {
+    const cutoff = getStaleCutoffIso(new Date('2024-06-15T12:00:00.000Z'));
+    expect(isBiographyStale(null, cutoff)).toBe(true);
+    expect(isBiographyStale(undefined, cutoff)).toBe(true);
+  });
+});
+
+describe('summarizeBiographies', () => {
+  it('counts only the populated optional fields per scraped bio', () => {
+    const summary = summarizeBiographies([
+      { birthDate: '1970-05-01', profession: 'Lawyer', education: 'Law degree' },
+      { birthDate: null, profession: 'Engineer', education: null },
+      { birthDate: '1985-09-12', profession: null, education: 'PhD' },
+    ]);
+
+    expect(summary.scraped).toBe(3);
+    expect(summary.withBirthDate).toBe(2);
+    expect(summary.withProfession).toBe(2);
+    expect(summary.withEducation).toBe(2);
+  });
+
+  it('returns zeroes for an empty input list', () => {
+    expect(summarizeBiographies([])).toEqual({
+      scraped: 0,
+      withBirthDate: 0,
+      withProfession: 0,
+      withEducation: 0,
+    });
+  });
+});

--- a/apps/watcher/src/transform/biography.ts
+++ b/apps/watcher/src/transform/biography.ts
@@ -9,11 +9,9 @@
 
 import { type BiographyData, fetchBiography } from '../scrapers/biography.js';
 import { supabase } from '../supabase.js';
+import { BIOGRAPHY_TTL_DAYS, getStaleCutoffIso, isBiographyStale } from './biography-helpers.js';
 
 const POLITENESS_DELAY_MS = 500;
-
-/** Number of days before a biography is considered stale and needs re-scraping */
-const BIOGRAPHY_TTL_DAYS = 7;
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -33,9 +31,7 @@ interface DeputyWithBiographyId {
  */
 async function getDeputiesWithBiographyId(forceAll = false): Promise<DeputyWithBiographyId[]> {
   // Calculate stale date threshold
-  const staleDate = new Date();
-  staleDate.setDate(staleDate.getDate() - BIOGRAPHY_TTL_DAYS);
-  const staleDateIso = staleDate.toISOString();
+  const staleDateIso = getStaleCutoffIso();
 
   // First, get all active deputies with biography_id
   const query = supabase
@@ -80,11 +76,9 @@ async function getDeputiesWithBiographyId(forceAll = false): Promise<DeputyWithB
   }
 
   // Filter to only deputies that need scraping (no biography or stale)
-  const needsScraping = deputies.filter((d) => {
-    const scrapedAt = scrapedAtMap.get(d.id);
-    if (!scrapedAt) return true; // Never scraped
-    return scrapedAt < staleDateIso; // Stale (older than TTL)
-  });
+  const needsScraping = deputies.filter((d) =>
+    isBiographyStale(scrapedAtMap.get(d.id), staleDateIso)
+  );
 
   return needsScraping.map((d) => ({
     id: d.id,

--- a/apps/watcher/src/transform/initiatives-helpers.ts
+++ b/apps/watcher/src/transform/initiatives-helpers.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure helpers for the initiatives transform.
+ *
+ * Extracted from `initiatives.ts` so the HTML vote-detail parser and the
+ * status-event picker can be unit-tested without importing supabase.
+ */
+
+export interface ParliamentEvento {
+  EvtId: string;
+  OevId: string;
+  Fase: string;
+  CodigoFase: string;
+  DataFase: string;
+  Votacao: unknown[] | null;
+}
+
+export interface ParliamentIniciativaLite {
+  IniEventos?: ParliamentEvento[];
+}
+
+/**
+ * Parse a Parliament `detalhe` HTML string into per-stance party lists.
+ *
+ * Input format (real shape, with raw HTML and inconsistent spacing):
+ *   "A Favor: <I>PSD</I>, <I> CDS-PP</I><BR>Contra:<I>CH</I>, <I> BE</I><BR>Abstenção:<I>PS</I>"
+ */
+export function parsePartyVoteDetail(detalhe: string): {
+  favor: string[];
+  against: string[];
+  abstain: string[];
+} {
+  const result = { favor: [] as string[], against: [] as string[], abstain: [] as string[] };
+
+  const clean = detalhe
+    .replace(/<BR>/gi, '\n')
+    .replace(/<\/?I>/gi, '')
+    .replace(/&nbsp;/gi, ' ')
+    .trim();
+
+  const lines = clean.split('\n');
+
+  for (const line of lines) {
+    const lowerLine = line.toLowerCase();
+    let parties: string[] = [];
+
+    const colonIndex = line.indexOf(':');
+    if (colonIndex > -1) {
+      const partyPart = line.substring(colonIndex + 1);
+      parties = partyPart
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0 && p.length < 20); // Sanity check
+    }
+
+    if (lowerLine.startsWith('a favor')) {
+      result.favor = parties;
+    } else if (lowerLine.startsWith('contra')) {
+      result.against = parties;
+    } else if (lowerLine.startsWith('abstenção') || lowerLine.startsWith('abstencao')) {
+      result.abstain = parties;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Pick the latest event's `Fase` (status label) for an initiative.
+ *
+ * Sorted lexicographically by `DataFase` (ISO dates compare correctly that way).
+ */
+export function getInitiativeStatus(ini: ParliamentIniciativaLite): string | undefined {
+  if (!ini.IniEventos || ini.IniEventos.length === 0) return undefined;
+
+  const sorted = [...ini.IniEventos].sort((a, b) =>
+    (a.DataFase || '').localeCompare(b.DataFase || '')
+  );
+  return sorted[sorted.length - 1]?.Fase;
+}

--- a/apps/watcher/src/transform/initiatives.test.ts
+++ b/apps/watcher/src/transform/initiatives.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test';
+import { getInitiativeStatus, parsePartyVoteDetail } from './initiatives-helpers.js';
+
+describe('parsePartyVoteDetail', () => {
+  it('parses real-shape detalhe with mixed casing, extra spaces and italic tags', () => {
+    const detalhe =
+      'A Favor: <I>PSD</I>, <I> CDS-PP</I><BR>Contra:<I>CH</I>, <I> BE</I><BR>Abstenção:<I>PS</I>';
+
+    const result = parsePartyVoteDetail(detalhe);
+
+    expect(result.favor).toEqual(['PSD', 'CDS-PP']);
+    expect(result.against).toEqual(['CH', 'BE']);
+    expect(result.abstain).toEqual(['PS']);
+  });
+
+  it('handles unaccented "Abstencao" header and an empty section', () => {
+    // No "Contra" line at all → against stays empty.
+    const detalhe = 'A Favor: <I>PS</I><BR>Abstencao:<I>IL</I>';
+
+    const result = parsePartyVoteDetail(detalhe);
+
+    expect(result.favor).toEqual(['PS']);
+    expect(result.against).toEqual([]);
+    expect(result.abstain).toEqual(['IL']);
+  });
+});
+
+describe('getInitiativeStatus', () => {
+  it('returns the Fase of the latest event by DataFase (ISO date)', () => {
+    const status = getInitiativeStatus({
+      IniEventos: [
+        {
+          EvtId: 'e1',
+          OevId: 'o1',
+          Fase: 'Apresentação',
+          CodigoFase: '10',
+          DataFase: '2024-01-01',
+          Votacao: null,
+        },
+        {
+          EvtId: 'e3',
+          OevId: 'o3',
+          Fase: 'Aprovação',
+          CodigoFase: '40',
+          DataFase: '2024-03-15',
+          Votacao: null,
+        },
+        {
+          EvtId: 'e2',
+          OevId: 'o2',
+          Fase: 'Discussão',
+          CodigoFase: '20',
+          DataFase: '2024-02-10',
+          Votacao: null,
+        },
+      ],
+    });
+    expect(status).toBe('Aprovação');
+  });
+
+  it('returns undefined when there are no events', () => {
+    expect(getInitiativeStatus({})).toBeUndefined();
+    expect(getInitiativeStatus({ IniEventos: [] })).toBeUndefined();
+  });
+});

--- a/apps/watcher/src/transform/initiatives.ts
+++ b/apps/watcher/src/transform/initiatives.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../supabase.js';
+import { getInitiativeStatus, parsePartyVoteDetail } from './initiatives-helpers.js';
 
 interface ParliamentVotacao {
   id: string;
@@ -40,51 +41,6 @@ interface DbPartyVote {
   parties_favor: string[];
   parties_against: string[];
   parties_abstain: string[];
-}
-
-function parsePartyVoteDetail(detalhe: string): {
-  favor: string[];
-  against: string[];
-  abstain: string[];
-} {
-  const result = { favor: [] as string[], against: [] as string[], abstain: [] as string[] };
-
-  // Parse format like:
-  // "A Favor: <I>PSD</I>, <I> CDS-PP</I><BR>Contra:<I>CH</I>, <I> BE</I><BR>Abstenção:<I>PS</I>"
-
-  // Clean HTML
-  const clean = detalhe
-    .replace(/<BR>/gi, '\n')
-    .replace(/<\/?I>/gi, '')
-    .replace(/&nbsp;/gi, ' ')
-    .trim();
-
-  const lines = clean.split('\n');
-
-  for (const line of lines) {
-    const lowerLine = line.toLowerCase();
-    let parties: string[] = [];
-
-    // Extract party names after the colon
-    const colonIndex = line.indexOf(':');
-    if (colonIndex > -1) {
-      const partyPart = line.substring(colonIndex + 1);
-      parties = partyPart
-        .split(',')
-        .map((p) => p.trim())
-        .filter((p) => p.length > 0 && p.length < 20); // Sanity check
-    }
-
-    if (lowerLine.startsWith('a favor')) {
-      result.favor = parties;
-    } else if (lowerLine.startsWith('contra')) {
-      result.against = parties;
-    } else if (lowerLine.startsWith('abstenção') || lowerLine.startsWith('abstencao')) {
-      result.abstain = parties;
-    }
-  }
-
-  return result;
 }
 
 export async function transformInitiatives(
@@ -190,16 +146,6 @@ export async function transformInitiatives(
   console.log(`   Questions identified: ${questionCounts.size} deputies with questions\n`);
 
   return { initiativeMap, partyVotes, authorCounts, questionCounts };
-}
-
-function getInitiativeStatus(ini: ParliamentIniciativa): string | undefined {
-  // Find the latest event
-  if (!ini.IniEventos || ini.IniEventos.length === 0) return undefined;
-
-  const sorted = [...ini.IniEventos].sort((a, b) =>
-    (a.DataFase || '').localeCompare(b.DataFase || '')
-  );
-  return sorted[sorted.length - 1]?.Fase;
 }
 
 export async function upsertPartyVotes(votes: DbPartyVote[]): Promise<void> {

--- a/apps/watcher/src/transform/photos-helpers.ts
+++ b/apps/watcher/src/transform/photos-helpers.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure helpers for the photos transform.
+ *
+ * Extracted from `photos.ts` so the validation and image-type detection
+ * helpers can be unit-tested without importing supabase.
+ */
+
+import sharp from 'sharp';
+
+// Thresholds for detecting placeholder images.
+export const MIN_PHOTO_FILE_SIZE = 5000; // 5KB - placeholders are usually smaller
+export const MIN_PHOTO_DIMENSION = 50; // 50px - minimum width/height for valid photos
+
+export interface PhotoValidation {
+  isValid: boolean;
+  isPlaceholder: boolean;
+  width?: number;
+  height?: number;
+  fileSize: number;
+  reason?: string;
+}
+
+/**
+ * Validate a photo buffer to detect Parliament placeholder images.
+ *
+ * A buffer is valid only when it is at least `MIN_PHOTO_FILE_SIZE` bytes,
+ * has dimensions >= `MIN_PHOTO_DIMENSION` on both axes, and parses as a
+ * known image format (JPEG/PNG via `sharp`).
+ */
+export async function validatePhoto(buffer: Buffer): Promise<PhotoValidation> {
+  const fileSize = buffer.length;
+
+  if (fileSize < MIN_PHOTO_FILE_SIZE) {
+    return {
+      isValid: false,
+      isPlaceholder: true,
+      fileSize,
+      reason: `File too small (${fileSize} bytes < ${MIN_PHOTO_FILE_SIZE})`,
+    };
+  }
+
+  try {
+    const metadata = await sharp(buffer).metadata();
+    const width = metadata.width || 0;
+    const height = metadata.height || 0;
+
+    if (width < MIN_PHOTO_DIMENSION || height < MIN_PHOTO_DIMENSION) {
+      return {
+        isValid: false,
+        isPlaceholder: true,
+        width,
+        height,
+        fileSize,
+        reason: `Dimensions too small (${width}x${height})`,
+      };
+    }
+
+    return {
+      isValid: true,
+      isPlaceholder: false,
+      width,
+      height,
+      fileSize,
+    };
+  } catch (err) {
+    return {
+      isValid: false,
+      isPlaceholder: false,
+      fileSize,
+      reason: `Failed to parse image metadata: ${err}`,
+    };
+  }
+}
+
+/**
+ * Detect whether a buffer's leading magic bytes match JPEG or PNG.
+ *
+ * Used to pick the storage filename extension. Defaults to `'jpg'` when the
+ * leading bytes are not a PNG signature, which mirrors the Parliament API
+ * (it returns JPEGs by default).
+ */
+export function detectImageType(buffer: Buffer): { extension: 'png' | 'jpg'; contentType: string } {
+  const isPng =
+    buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47;
+
+  return isPng
+    ? { extension: 'png', contentType: 'image/png' }
+    : { extension: 'jpg', contentType: 'image/jpeg' };
+}

--- a/apps/watcher/src/transform/photos.test.ts
+++ b/apps/watcher/src/transform/photos.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import sharp from 'sharp';
+import { MIN_PHOTO_FILE_SIZE, detectImageType, validatePhoto } from './photos-helpers.js';
+
+describe('detectImageType', () => {
+  it('identifies PNG magic bytes and defaults the rest to JPEG', () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(detectImageType(png)).toEqual({ extension: 'png', contentType: 'image/png' });
+
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    expect(detectImageType(jpeg)).toEqual({ extension: 'jpg', contentType: 'image/jpeg' });
+
+    // Garbage bytes still fall back to JPEG (matches production behaviour).
+    const garbage = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    expect(detectImageType(garbage)).toEqual({ extension: 'jpg', contentType: 'image/jpeg' });
+  });
+});
+
+describe('validatePhoto', () => {
+  it('flags small buffers as placeholders before parsing', async () => {
+    const tiny = Buffer.alloc(MIN_PHOTO_FILE_SIZE - 1, 0xff);
+    const result = await validatePhoto(tiny);
+
+    expect(result.isValid).toBe(false);
+    expect(result.isPlaceholder).toBe(true);
+    expect(result.fileSize).toBe(MIN_PHOTO_FILE_SIZE - 1);
+    expect(result.reason).toContain('File too small');
+  });
+
+  it('accepts a real-shape JPEG above all thresholds', async () => {
+    // Generate a noisy 400x400 JPEG so the encoded output exceeds the
+    // 5KB placeholder threshold (a solid colour compresses below it).
+    const pixels = Buffer.alloc(400 * 400 * 3);
+    for (let i = 0; i < pixels.length; i++) pixels[i] = (i * 37) & 0xff;
+
+    const buffer = await sharp(pixels, {
+      raw: { width: 400, height: 400, channels: 3 },
+    })
+      .jpeg({ quality: 90 })
+      .toBuffer();
+
+    expect(buffer.length).toBeGreaterThan(MIN_PHOTO_FILE_SIZE);
+
+    const result = await validatePhoto(buffer);
+
+    expect(result.isValid).toBe(true);
+    expect(result.isPlaceholder).toBe(false);
+    expect(result.width).toBe(400);
+    expect(result.height).toBe(400);
+  });
+});

--- a/apps/watcher/src/transform/photos.ts
+++ b/apps/watcher/src/transform/photos.ts
@@ -1,77 +1,16 @@
-import sharp from 'sharp';
 import { downloadBiographyPhoto, fetchBiographyPhotoUrl } from '../scrapers/biography.js';
 import { supabase } from '../supabase.js';
+import { detectImageType, validatePhoto } from './photos-helpers.js';
+
+export { validatePhoto } from './photos-helpers.js';
 
 const PARLIAMENT_PHOTO_URL = 'https://app.parlamento.pt/webutils/getimage.aspx';
 const NOPHOTO_REDIRECT_PATH = '/webutils/nophoto.jpg';
-
-// Thresholds for detecting placeholder images
-const MIN_PHOTO_FILE_SIZE = 5000; // 5KB - placeholders are usually smaller
-const MIN_PHOTO_DIMENSION = 50; // 50px - minimum width/height for valid photos
 
 interface PhotoUploadResult {
   success: boolean;
   url?: string;
   error?: string;
-}
-
-interface PhotoValidation {
-  isValid: boolean;
-  isPlaceholder: boolean;
-  width?: number;
-  height?: number;
-  fileSize: number;
-  reason?: string;
-}
-
-/**
- * Validate photo buffer to detect placeholders
- */
-export async function validatePhoto(buffer: Buffer): Promise<PhotoValidation> {
-  const fileSize = buffer.length;
-
-  // Too small - likely a placeholder
-  if (fileSize < MIN_PHOTO_FILE_SIZE) {
-    return {
-      isValid: false,
-      isPlaceholder: true,
-      fileSize,
-      reason: `File too small (${fileSize} bytes < ${MIN_PHOTO_FILE_SIZE})`,
-    };
-  }
-
-  try {
-    const metadata = await sharp(buffer).metadata();
-    const width = metadata.width || 0;
-    const height = metadata.height || 0;
-
-    // Check dimensions
-    if (width < MIN_PHOTO_DIMENSION || height < MIN_PHOTO_DIMENSION) {
-      return {
-        isValid: false,
-        isPlaceholder: true,
-        width,
-        height,
-        fileSize,
-        reason: `Dimensions too small (${width}x${height})`,
-      };
-    }
-
-    return {
-      isValid: true,
-      isPlaceholder: false,
-      width,
-      height,
-      fileSize,
-    };
-  } catch (err) {
-    return {
-      isValid: false,
-      isPlaceholder: false,
-      fileSize,
-      reason: `Failed to parse image metadata: ${err}`,
-    };
-  }
 }
 
 /**
@@ -149,14 +88,7 @@ export async function uploadPhotoToStorage(
   photoBuffer: Buffer
 ): Promise<PhotoUploadResult> {
   // Detect image type from magic bytes
-  const isPng =
-    photoBuffer[0] === 0x89 &&
-    photoBuffer[1] === 0x50 &&
-    photoBuffer[2] === 0x4e &&
-    photoBuffer[3] === 0x47;
-
-  const extension = isPng ? 'png' : 'jpg';
-  const contentType = isPng ? 'image/png' : 'image/jpeg';
+  const { extension, contentType } = detectImageType(photoBuffer);
   const fileName = `${depId}.${extension}`;
 
   try {

--- a/apps/watcher/src/transform/stats-helpers.ts
+++ b/apps/watcher/src/transform/stats-helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure helpers for the stats transform.
+ *
+ * Extracted from `stats.ts` so the per-party vote aggregation can be
+ * unit-tested without importing supabase.
+ */
+
+export interface PartyVoteRow {
+  parties_favor: string[] | null;
+  parties_against: string[] | null;
+  parties_abstain: string[] | null;
+}
+
+export interface PartyVoteCounts {
+  favor: number;
+  against: number;
+  abstain: number;
+  total: number;
+}
+
+/**
+ * Aggregate per-party vote tallies from a flat list of `party_votes` rows.
+ *
+ * For each row, every party listed in `parties_favor`/`parties_against`/
+ * `parties_abstain` gets +1 in the matching bucket and +1 in `total`. Rows
+ * with null/undefined arrays are tolerated (treated as empty).
+ */
+export function aggregatePartyVoteCounts(votes: PartyVoteRow[]): Map<string, PartyVoteCounts> {
+  const partyCounts = new Map<string, PartyVoteCounts>();
+
+  const bump = (party: string, key: 'favor' | 'against' | 'abstain') => {
+    const current = partyCounts.get(party) || { favor: 0, against: 0, abstain: 0, total: 0 };
+    current[key]++;
+    current.total++;
+    partyCounts.set(party, current);
+  };
+
+  for (const vote of votes) {
+    for (const party of vote.parties_favor || []) bump(party, 'favor');
+    for (const party of vote.parties_against || []) bump(party, 'against');
+    for (const party of vote.parties_abstain || []) bump(party, 'abstain');
+  }
+
+  return partyCounts;
+}

--- a/apps/watcher/src/transform/stats.test.ts
+++ b/apps/watcher/src/transform/stats.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { aggregatePartyVoteCounts } from './stats-helpers.js';
+
+describe('aggregatePartyVoteCounts', () => {
+  it('tallies favor/against/abstain per party across multiple votes', () => {
+    const counts = aggregatePartyVoteCounts([
+      // Vote 1: PS favor; PSD/CH against; IL abstain.
+      {
+        parties_favor: ['PS'],
+        parties_against: ['PSD', 'CH'],
+        parties_abstain: ['IL'],
+      },
+      // Vote 2: PS favor again; PSD favor; nobody against.
+      {
+        parties_favor: ['PS', 'PSD'],
+        parties_against: [],
+        parties_abstain: ['IL'],
+      },
+    ]);
+
+    expect(counts.get('PS')).toEqual({ favor: 2, against: 0, abstain: 0, total: 2 });
+    expect(counts.get('PSD')).toEqual({ favor: 1, against: 1, abstain: 0, total: 2 });
+    expect(counts.get('CH')).toEqual({ favor: 0, against: 1, abstain: 0, total: 1 });
+    expect(counts.get('IL')).toEqual({ favor: 0, against: 0, abstain: 2, total: 2 });
+  });
+
+  it('tolerates rows with null arrays and an empty input list', () => {
+    expect(aggregatePartyVoteCounts([]).size).toBe(0);
+
+    const counts = aggregatePartyVoteCounts([
+      { parties_favor: null, parties_against: null, parties_abstain: null },
+      { parties_favor: ['BE'], parties_against: null, parties_abstain: null },
+    ]);
+
+    expect(counts.size).toBe(1);
+    expect(counts.get('BE')).toEqual({ favor: 1, against: 0, abstain: 0, total: 1 });
+  });
+});

--- a/apps/watcher/src/transform/stats.ts
+++ b/apps/watcher/src/transform/stats.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../supabase.js';
+import { aggregatePartyVoteCounts } from './stats-helpers.js';
 
 interface DeputyStatsUpdate {
   deputy_id: string;
@@ -95,31 +96,7 @@ export async function updatePartyVoteStats(partyMap: Map<string, string>): Promi
   }
 
   // Count votes per party
-  const partyCounts = new Map<
-    string,
-    { favor: number; against: number; abstain: number; total: number }
-  >();
-
-  for (const vote of votes || []) {
-    for (const party of vote.parties_favor || []) {
-      const current = partyCounts.get(party) || { favor: 0, against: 0, abstain: 0, total: 0 };
-      current.favor++;
-      current.total++;
-      partyCounts.set(party, current);
-    }
-    for (const party of vote.parties_against || []) {
-      const current = partyCounts.get(party) || { favor: 0, against: 0, abstain: 0, total: 0 };
-      current.against++;
-      current.total++;
-      partyCounts.set(party, current);
-    }
-    for (const party of vote.parties_abstain || []) {
-      const current = partyCounts.get(party) || { favor: 0, against: 0, abstain: 0, total: 0 };
-      current.abstain++;
-      current.total++;
-      partyCounts.set(party, current);
-    }
-  }
+  const partyCounts = aggregatePartyVoteCounts(votes || []);
 
   console.log('  Party vote counts:');
   for (const [party, counts] of partyCounts) {


### PR DESCRIPTION
Closes ADA-212.

## What

Adds unit-test coverage for the six transform modules in
`apps/watcher/src/transform/` that ran daily without any tests:

| Module | New tests | Helper file extracted | Fixture? |
|---|---:|---|---|
| `activities.ts` | 4 | `activities-helpers.ts` | inline |
| `attendance.ts` | 3 | `attendance-helpers.ts` | inline |
| `biography.ts` | 4 | `biography-helpers.ts` | inline |
| `initiatives.ts` | 4 | `initiatives-helpers.ts` | inline |
| `stats.ts` | 2 | `stats-helpers.ts` | inline |
| `photos.ts` | 3 | `photos-helpers.ts` | inline (sharp-generated buffer) |

20 tests in total across 6 new `*.test.ts` files. Watcher suite goes
91 -> 111 passing, 0 failing. Web suite unchanged.

## Why

Each transform is run by the daily watcher sync to produce numbers that
end up on user-facing pages (intervention counts, party vote tallies,
attendance matching, etc.). Until now there was zero unit-level
guardrail against subtle regressions in their pure logic.

## How

Each transform module imported `supabase.ts` at the top, which throws
at import time when env vars are absent. To test the pure logic
without that failure, each module now has a sibling
`<module>-helpers.ts` containing the pure pieces (parsers, fuzzy
matchers, aggregators, validators). The production module imports from
the helper, so runtime behaviour is unchanged - this is a pure refactor
on the production side, plus net-new test files.

Notable per-module decisions:

- **`biography.ts`**: TTL/staleness logic was previously inlined inside
  the supabase-bound fetcher. Extracted `getStaleCutoffIso` +
  `isBiographyStale` so the predicate is testable, and added
  `summarizeBiographies` for the summary counters. The biography
  transform itself remains thoroughly supabase-bound; pure-logic
  coverage is shallower than ideal here. Honest scope note: this PR
  does not exercise the fetch/upsert orchestration - that needs an
  integration setup we don't currently have.
- **`photos.ts`**: `validatePhoto` was already exported; moved it (and
  the magic-byte detector) to the helper file so tests can import them
  without pulling in the supabase storage code. The "real photo" test
  generates a 400x400 noisy JPEG via `sharp` in the test itself - a
  solid-colour image compresses below the 5KB placeholder threshold,
  so the noise pattern is necessary.
- **`stats.ts`**: only the `aggregatePartyVoteCounts` reducer was pure
  enough to extract; the per-deputy and per-party update functions are
  thin supabase wrappers and were left as-is.

No new dependencies. No fixtures committed: each helper has narrow,
well-typed inputs and the `apps/watcher/snapshots/` directory referenced
in the original task brief does not exist in this repo, so synthetic
inputs constructed in-test were the cleanest option.

## Compliance with the "definitely-do-NOT" list

- [x] No real Supabase hits.
- [x] No `if (!supabase) return;` silent passes.
- [x] No `it.skip` / `test.skip` to dodge difficulty.
- [x] No `mock.module(...)` shenanigans - tests import the pure helpers
  directly.
- [x] No new dependencies.

## Testing

- [x] `cd apps/watcher && bun test` -> 111 pass / 20 skip / 0 fail
- [x] `bun run test` (root) -> watcher + web both green
- [x] `cd apps/watcher && bun run typecheck` -> clean
- [x] `cd apps/watcher && bun run lint` (biome) -> clean
- [x] Pre-push hook ran the full unit suite and passed before push