### PR TITLE
chore: workflow hardening (silent-pass test fix + AI agent docs)

### DIFF
--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -130,11 +130,15 @@ test.describe('Navigation', () => {
 
   // Issue #21: Remove unused WhatHappened page
   // @see https://github.com/bcamarneiro/adamastor/issues/21
-  test('/what-happened should not exist (returns 404)', async ({ page }) => {
-    const response = await page.goto('/what-happened');
+  test('/what-happened should not exist (renders 404 page)', async ({ page }) => {
+    await page.goto('/what-happened');
+    await page.waitForLoadState('networkidle');
 
-    const status = response?.status();
-    expect(status === 404 || page.url() !== '/what-happened').toBeTruthy();
+    // SPA returns 200 for unknown routes (Vercel rewrite), so we assert on
+    // the rendered 404 page instead of the HTTP status. The previous
+    // assertion compared `page.url()` (a full URL) to '/what-happened' (a
+    // relative path), which was always truthy regardless of behavior.
+    await expect(page).toHaveTitle(/Página não encontrada/i);
   });
 
   // Issue #118: Correct GitHub repository link on About page

--- a/docs/AI_AGENTS.md
+++ b/docs/AI_AGENTS.md
@@ -374,6 +374,78 @@ export const mockParties = [
 import { mockParties } from './__fixtures__/parties';
 ```
 
+### Avoid Silent-Pass Anti-Patterns
+
+A test that passes when broken is worse than no test — it manufactures
+false confidence. Watch for these patterns and prefer `it.skipIf` or
+explicit assertions instead.
+
+```typescript
+// ❌ Bad: silent pass when env not configured
+it('queries deputies', async () => {
+  if (!supabase) return; // ← test reports as PASS with zero assertions
+  const { data } = await supabase.from('deputies').select();
+  expect(data?.length).toBeGreaterThan(0);
+});
+
+// ✅ Good: skip is loud, pass means assertions ran
+const hasSupabase = await isSupabaseReachable();
+it.skipIf(!hasSupabase)('queries deputies', async () => {
+  const { data } = await supabase.from('deputies').select();
+  expect(data?.length).toBeGreaterThan(0);
+});
+```
+
+```typescript
+// ❌ Bad: comparing full URL to relative path is always truthy
+expect(page.url() !== '/what-happened').toBeTruthy();
+
+// ❌ Bad: getByRole/getByText already throws if not found,
+// then .toBeTruthy() adds nothing — and worse, in non-strict mode
+// can match unrelated elements
+expect(screen.getByText('A')).toBeTruthy();
+
+// ✅ Good: explicit visibility / title / count assertions
+await expect(page).toHaveTitle(/Página não encontrada/i);
+await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+```
+
+```typescript
+// ❌ Bad: conditional assertion — silently passes if data is missing
+if ((await badge.count()) > 0) {
+  expect(await badge.first().textContent()).not.toContain('ª');
+}
+
+// ✅ Good: assert presence first, then content
+await expect(badge.first()).toBeVisible();
+expect(await badge.first().textContent()).not.toContain('ª');
+```
+
+### Beware Eager Imports When Extracting Constants
+
+When a module has top-level side effects (e.g. `apps/watcher/src/supabase.ts`
+throws if env vars are missing), don't add new exports to it for tests to
+import — the import alone triggers the side effect. Extract to a sibling
+module instead.
+
+```typescript
+// ❌ Bad: tests now load supabase just to read color constants
+// parties.ts
+import { supabase } from '../supabase.js'; // throws without env
+export const PARTY_COLORS = { ... };
+export async function transformParties(...) { /* uses supabase */ }
+
+// ✅ Good: pure constants live in a side-effect-free file
+// parties-colors.ts ← no supabase import
+export const PARTY_COLORS = { ... };
+export function getPartyColor(acronym: string) { ... }
+
+// parties.ts ← unchanged behavior, re-exports for backwards compat
+import { supabase } from '../supabase.js';
+import { getPartyColor } from './parties-colors.js';
+export { PARTY_COLORS, getPartyColor } from './parties-colors.js';
+```
+
 ### E2E Regression Tests for Bug Fixes
 
 **Location:** Add tests to the appropriate thematic spec file in `apps/web/e2e/`:


### PR DESCRIPTION
## Summary

Concrete improvements from the retrospective on the recent bug-fix sweep (PRs #294-#301).

### 1. Fix silent-pass test in \`apps/web/e2e/navigation.spec.ts\`
The \`/what-happened should not exist\` test compared \`page.url()\` (a full URL like \`http://localhost:5173/what-happened\`) to \`'/what-happened'\` (a relative path) — always truthy, always passed. Replaced with an assertion on the 404 page title that PR #299 made meaningful.

### 2. Document anti-patterns in \`docs/AI_AGENTS.md\`
Two new subsections under Testing Patterns:
- **Avoid Silent-Pass Anti-Patterns** — env-gated \`if (!supabase) return\` (we removed 15 of these in #296), \`page.url()\`-vs-path mismatches (#300), conditional \`if (count > 0)\` checks (#300), \`getBy*\` + \`.toBeTruthy()\` redundancy.
- **Beware Eager Imports When Extracting Constants** — documents the \`parties.ts\` → \`parties-colors.ts\` split that #297 had to do mid-flight.

### 3. Enable auto-merge on the repo
Out-of-band: \`gh api -X PATCH repos/bcamarneiro/adamastor -f allow_auto_merge=true\`. Future PRs can use \`gh pr merge --auto\` instead of \`--admin\` once required checks pass.

## Out of scope (deferred)
- The SPA returns HTTP 200 for unknown routes (Vercel rewrite) — still surfaces in the \`/what-happened\` test, which now compensates by asserting on title. A proper fix needs a Vercel-level routing decision.
- The smoke-test audit found two routes \`/page\` (in e2e README example only, harmless) and \`/what-happened\` (this PR). No other suspicious-route fragility surfaced.

## Testing
- [x] Pre-push hook green
- [ ] Auto-merge enabled — testing it on this very PR (\`--auto --squash\`)