### PR TITLE
fix(web): link deputy rows on /parliament (ADA-216)

### DIFF
--- a/apps/web/src/pages/ParliamentPage/ParliamentList/ParliamentList.test.tsx
+++ b/apps/web/src/pages/ParliamentPage/ParliamentList/ParliamentList.test.tsx
@@ -39,6 +39,14 @@ vi.mock('@/services/parliament/useParliament', () => ({
   useParliament: () => mockHookState,
 }));
 
+// Mock the useDeputyIdMap hook with a permissive default that maps every
+// possible DepId (numeric MP id) to a synthetic Supabase UUID. Individual
+// tests can override behaviour via `mockDeputyIdMap`.
+let mockDeputyIdMap: Map<string, string> = new Map();
+vi.mock('@/services/reportCard/useDeputyIdMap', () => ({
+  useDeputyIdMap: () => ({ data: mockDeputyIdMap }),
+}));
+
 // Mock react-router-dom Link component
 vi.mock('react-router-dom', () => ({
   Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
@@ -112,6 +120,11 @@ function resetMockState() {
     isSuccess: true,
     error: null,
   };
+  // Build a generous default id map so every mock MP becomes clickable.
+  mockDeputyIdMap = new Map();
+  for (let i = 0; i < 250; i++) {
+    mockDeputyIdMap.set(String(i), `uuid-${i}`);
+  }
 }
 
 // Helper to set mock state for specific test scenarios
@@ -620,6 +633,49 @@ describe('ParliamentList', () => {
       // Should NOT appear when filtering by old party (PS not in the dropdown since MP is in PSD now)
       // The PS option won't exist since there are no MPs currently in PS
       expect(screen.queryByRole('option', { name: 'PS' })).toBeNull();
+    });
+  });
+
+  // Issue ADA-216: deputy rows on /parliament must be clickable links to the
+  // deputy detail page. Regression coverage for the bug where rows rendered
+  // but had no <Link>/<a> wrapping.
+  describe('Deputy row links (ADA-216)', () => {
+    it('should render each deputy row as a link to /deputado/:id', () => {
+      const mp = createMockMP({
+        DepId: 42,
+        DepNomeParlamentar: 'João Silva',
+      });
+      setMockState({
+        parliament: createMockParliamentData({ mps: [mp] }),
+        metadata: createMockParliamentMetadata({ total: 1 }),
+      });
+      // Map the parliament DepId -> a Supabase UUID
+      mockDeputyIdMap.set('42', 'uuid-42');
+
+      render(<ParliamentList />);
+
+      const link = screen.getByRole('link', { name: /Ver perfil de João Silva/i });
+      expect(link).toBeTruthy();
+      expect(link.getAttribute('href')).toBe('/deputado/uuid-42');
+    });
+
+    it('should NOT render a link when the deputy is missing from the id map', () => {
+      const mp = createMockMP({
+        DepId: 999,
+        DepNomeParlamentar: 'Sem Mapeamento',
+      });
+      setMockState({
+        parliament: createMockParliamentData({ mps: [mp] }),
+        metadata: createMockParliamentMetadata({ total: 1 }),
+      });
+      // No entry for DepId 999 in the map
+      mockDeputyIdMap.delete('999');
+
+      render(<ParliamentList />);
+
+      // Name still renders, but not as a link
+      expect(screen.getByText('Sem Mapeamento')).toBeTruthy();
+      expect(screen.queryByRole('link', { name: /Ver perfil de Sem Mapeamento/i })).toBeNull();
     });
   });
 });

--- a/apps/web/src/pages/ParliamentPage/ParliamentList/ParliamentList.tsx
+++ b/apps/web/src/pages/ParliamentPage/ParliamentList/ParliamentList.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { Building, Filter, Landmark, MapPin, Search, Users, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { EmptyState } from '@/components/data/EmptyState';
 import { ErrorState } from '@/components/data/ErrorState';
@@ -13,9 +14,11 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { PARTY_COLORS } from '@/services/parliament/constants';
 import { useParliament } from '@/services/parliament/useParliament';
+import { useDeputyIdMap } from '@/services/reportCard/useDeputyIdMap';
 
 const ParliamentList = () => {
   const { parliament, metadata, isLoading, isError, error } = useParliament();
+  const { data: deputyIdMap } = useDeputyIdMap();
   const [filterText, setFilterText] = useState('');
   const [selectedDistrict, setSelectedDistrict] = useState<string>('');
   const [selectedParty, setSelectedParty] = useState<string>('');
@@ -308,6 +311,48 @@ const ParliamentList = () => {
               const currentParty = mp.DepGP[mp.DepGP.length - 1]?.gpSigla;
               const currentStatus = mp.DepSituacao[mp.DepSituacao.length - 1]?.sioDes;
               const partyColor = PARTY_COLORS[currentParty] || '#666';
+              const supabaseId = deputyIdMap?.get(String(mp.DepId));
+
+              const cardInner = (
+                <div className="flex items-start gap-4">
+                  {/* Avatar placeholder */}
+                  <div
+                    className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full"
+                    style={{ backgroundColor: `${partyColor}20` }}
+                  >
+                    <Building className="h-6 w-6" style={{ color: partyColor }} />
+                  </div>
+
+                  {/* Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-semibold text-neutral-12 truncate group-hover:text-accent-9 transition-colors">
+                      {mp.DepNomeParlamentar}
+                    </div>
+                    <div className="text-sm text-neutral-11 truncate">{mp.DepNomeCompleto}</div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      {currentParty && (
+                        <Badge
+                          style={{
+                            backgroundColor: partyColor,
+                            color: 'white',
+                          }}
+                        >
+                          {currentParty}
+                        </Badge>
+                      )}
+                      <span className="text-xs text-neutral-9">{mp.DepCPDes}</span>
+                    </div>
+                    {currentStatus && currentStatus !== 'Efetivo' && (
+                      <Badge variant="secondary" className="mt-2">
+                        {currentStatus}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              );
+
+              const cardClassName =
+                'group block rounded-xl border border-neutral-4 bg-white p-4 hover:border-accent-7 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-9 transition-all duration-300';
 
               return (
                 <motion.div
@@ -316,43 +361,18 @@ const ParliamentList = () => {
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: Math.min(index * 0.02, 0.3), duration: 0.4 }}
-                  className="group rounded-xl border border-neutral-4 bg-white p-4 hover:border-accent-7 hover:shadow-lg transition-all duration-300"
                 >
-                  <div className="flex items-start gap-4">
-                    {/* Avatar placeholder */}
-                    <div
-                      className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full"
-                      style={{ backgroundColor: `${partyColor}20` }}
+                  {supabaseId ? (
+                    <Link
+                      to={`/deputado/${supabaseId}`}
+                      aria-label={`Ver perfil de ${mp.DepNomeParlamentar}`}
+                      className={cardClassName}
                     >
-                      <Building className="h-6 w-6" style={{ color: partyColor }} />
-                    </div>
-
-                    {/* Info */}
-                    <div className="flex-1 min-w-0">
-                      <div className="font-semibold text-neutral-12 truncate group-hover:text-accent-9 transition-colors">
-                        {mp.DepNomeParlamentar}
-                      </div>
-                      <div className="text-sm text-neutral-11 truncate">{mp.DepNomeCompleto}</div>
-                      <div className="mt-2 flex flex-wrap items-center gap-2">
-                        {currentParty && (
-                          <Badge
-                            style={{
-                              backgroundColor: partyColor,
-                              color: 'white',
-                            }}
-                          >
-                            {currentParty}
-                          </Badge>
-                        )}
-                        <span className="text-xs text-neutral-9">{mp.DepCPDes}</span>
-                      </div>
-                      {currentStatus && currentStatus !== 'Efetivo' && (
-                        <Badge variant="secondary" className="mt-2">
-                          {currentStatus}
-                        </Badge>
-                      )}
-                    </div>
-                  </div>
+                      {cardInner}
+                    </Link>
+                  ) : (
+                    <div className={cardClassName}>{cardInner}</div>
+                  )}
                 </motion.div>
               );
             })}

--- a/apps/web/src/services/reportCard/index.ts
+++ b/apps/web/src/services/reportCard/index.ts
@@ -2,4 +2,5 @@ export { useDistrictByPostal } from './useDistrictByPostal';
 export { useDeputiesByDistrict } from './useDeputiesByDistrict';
 export { useDeputiesByParty } from './useDeputiesByParty';
 export { useDeputyDetail } from './useDeputyDetail';
+export { useDeputyIdMap } from './useDeputyIdMap';
 export { useNationalAverages } from './useNationalAverages';

--- a/apps/web/src/services/reportCard/useDeputyIdMap.ts
+++ b/apps/web/src/services/reportCard/useDeputyIdMap.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../../lib/supabase';
+
+/**
+ * Fetches a mapping from Parliament API `external_id` (a.k.a. `DepId`) to the
+ * Supabase deputy `id` (UUID). Used by pages that source their list from the
+ * Parliament API (e.g. /parliament) but need to link to /deputado/:deputyId
+ * which uses the Supabase UUID.
+ */
+async function fetchDeputyIdMap(): Promise<Map<string, string>> {
+  const { data, error } = await supabase
+    .from('deputy_details')
+    .select('id, external_id')
+    .eq('is_active', true);
+
+  if (error) {
+    console.error('Error fetching deputy id map:', error);
+    throw new Error('Erro ao carregar mapa de deputados');
+  }
+
+  const map = new Map<string, string>();
+  for (const row of data || []) {
+    if (row.external_id && row.id) {
+      map.set(String(row.external_id), row.id);
+    }
+  }
+  return map;
+}
+
+export function useDeputyIdMap() {
+  return useQuery({
+    queryKey: ['deputy-id-map'],
+    queryFn: fetchDeputyIdMap,
+    staleTime: 1000 * 60 * 60, // 1 hour - data syncs daily
+  });
+}


### PR DESCRIPTION
Closes ADA-216

## What
The `/parliament` page rendered 230 deputy cards (with search, count, and filters) but **none of the rows were clickable**. There were zero `<Link>`/`<a href="/deputado/...">` elements in `ParliamentList.tsx`, so users had no way to navigate from the parliament list to a deputy's detail page.

## Why
Visiting `/parliament` is a natural entry point for browsing the legislature. Without clickable rows it's a dead-end view — users can see who the deputies are but cannot drill into anyone's report card.

## How
- Wrapped each deputy card in a `react-router-dom` `<Link>`, mirroring the pattern in `apps/web/src/components/Leaderboard/LeaderboardCard.tsx` (whole-row Link, `group` hover state, `focus-visible` ring, `aria-label="Ver perfil de {name}"`).
- The Parliament API exposes deputies via numeric `DepId`, but `/deputado/:deputyId` resolves a Supabase UUID. Added a small `useDeputyIdMap` hook (`apps/web/src/services/reportCard/useDeputyIdMap.ts`) that fetches `{id, external_id}` from `deputy_details` and returns a `DepId → UUID` `Map`.
- Rows for deputies missing from the map fall back to a non-clickable `div` so layout is preserved (instead of producing 404 links).
- No nested-interactive a11y concerns: the existing card body contains only text/badges, no buttons or links, so wrapping the whole row in `<Link>` is safe.

## Testing
- [x] Unit tests pass — 543/543 in `apps/web` (added 2 new regression tests in `ParliamentList.test.tsx` covering the linked case and the unmapped fallback)
- [x] Lint passes (`bun run lint`)
- [x] Pre-push hook test suite green
- [ ] Manual: visit `/parliament`, click any deputy → lands on `/deputado/<uuid>`