### PR TITLE
[BRU-840] Disclose intervention counts are party-level estimates

### DIFF
--- a/apps/watcher/src/transform/activities.ts
+++ b/apps/watcher/src/transform/activities.ts
@@ -73,10 +73,11 @@ export async function countInterventions(
   return interventionCounts;
 }
 
-// Note: The Parliament API doesn't provide individual deputy intervention counts directly.
-// We can only count at the party level from debates.
-// For individual deputy stats, we'll distribute party interventions proportionally
-// or mark as "estimated from party data".
+// IMPORTANT: The Parliament API only provides debate intervention counts at the
+// party level (countInterventions). This function distributes each party's total
+// evenly across all its active deputies — it does NOT reflect actual per-deputy
+// speech counts. A silent backbencher gets the same value as the party's most
+// vocal member. This limitation is disclosed on the Methodology page.
 
 export async function distributeInterventionsToDeputies(
   interventionsByParty: Map<string, number>,

--- a/apps/web/src/pages/MethodologyPage/methodology-pt.md
+++ b/apps/web/src/pages/MethodologyPage/methodology-pt.md
@@ -29,6 +29,10 @@ Pontuação = (Assiduidade × 0.40) +
             (Perguntas/Média × 0.10)
 ```
 
+### Nota sobre as Intervenções em Debates
+
+A API do Parlamento fornece o número total de intervenções em debates apenas ao nível do partido — não por deputado individual. Para obter um valor por deputado, dividimos o total do partido de forma igual por todos os deputados ativos desse partido. Isto significa que o componente de intervenções é uma **estimativa ao nível do partido**, não uma contagem real das intervenções individuais de cada deputado. Um deputado que nunca interveio num debate recebe o mesmo valor que um colega de partido que falou dezenas de vezes.
+
 ## Sistema de Notas
 
 As notas de A a F são atribuídas com base na pontuação de trabalho:


### PR DESCRIPTION
The Parliament API only provides debate intervention counts at the party level. The pipeline divides each party total evenly across all its active deputies. The Methodology page did not disclose this.

Changes:
- methodology-pt.md: Added Nota sobre as Intervenções em Debates section
- activities.ts: Clarified code comment above distributeInterventionsToDeputies

All 647 tests pass. Lint and typecheck clean.