### PR TITLE
feat(metrics): Legislative Efficiency Score Calculator (BRU-878)

### DIFF
--- a/apps/web/src/services/metrics/EfficiencyScoreCalculator.test.ts
+++ b/apps/web/src/services/metrics/EfficiencyScoreCalculator.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EfficiencyScoreCalculator,
+  ACTIVITY_WEIGHTS,
+  EFFICIENCY_LABELS,
+  EFFICIENCY_THRESHOLDS,
+  OUTPUT_WEIGHTS,
+} from './EfficiencyScoreCalculator';
+import type {
+  ActivityMetrics,
+  OutputMetrics,
+} from './EfficiencyScoreCalculator';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A typical active deputy — attends most sessions, moderate activity. */
+const typicalActivity: ActivityMetrics = {
+  attendanceRate: 85,
+  proposalsSubmitted: 12,
+  interventionsMade: 30,
+  questionsAsked: 10,
+};
+
+/** Typical output — good vote participation, decent attendance record. */
+const typicalOutput: OutputMetrics = {
+  votesCast: 450,
+  totalVotes: 500,
+  sessionsAttended: 40,
+  totalSessions: 50,
+};
+
+// ---------------------------------------------------------------------------
+// Activity vs Output distinction
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
+  it('should assign a lower efficiency score when activity is high but output is low', () => {
+    const busyButIneffective = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 95,
+        proposalsSubmitted: 100,
+        interventionsMade: 80,
+        questionsAsked: 50,
+      },
+      {
+        votesCast: 50,
+        totalVotes: 500,
+        sessionsAttended: 10,
+        totalSessions: 50,
+      },
+    );
+
+    // High activity, low output → efficiency should be low
+    expect(busyButIneffective.activityScore).toBeGreaterThan(70);
+    expect(busyButIneffective.outputScore).toBeLessThan(20);
+    expect(busyButIneffective.efficiencyRatio).toBeLessThan(0.3);
+    expect(busyButIneffective.efficiencyScore).toBeLessThan(20);
+  });
+
+  it('should assign a higher efficiency score when output matches or exceeds activity norm', () => {
+    const effective = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 80,
+        proposalsSubmitted: 8,
+        interventionsMade: 20,
+        questionsAsked: 5,
+      },
+      {
+        votesCast: 490,
+        totalVotes: 500,
+        sessionsAttended: 48,
+        totalSessions: 50,
+      },
+    );
+
+    // Moderate activity, high output → efficiency should be high
+    expect(effective.activityScore).toBeLessThan(80);
+    expect(effective.outputScore).toBeGreaterThan(80);
+    expect(effective.efficiencyRatio).toBeGreaterThan(1);
+    expect(effective.efficiencyScore).toBeGreaterThan(50);
+  });
+
+  it('should distinguish a "talker" (high interventions) from a "doer" (high vote participation)', () => {
+    const talker = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 70,
+        proposalsSubmitted: 5,
+        interventionsMade: 200, // speaks a lot
+        questionsAsked: 3,
+      },
+      {
+        votesCast: 100,
+        totalVotes: 500,
+        sessionsAttended: 20,
+        totalSessions: 50,
+      },
+    );
+
+    const doer = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 90,
+        proposalsSubmitted: 15,
+        interventionsMade: 20, // speaks less
+        questionsAsked: 8,
+      },
+      {
+        votesCast: 495,
+        totalVotes: 500,
+        sessionsAttended: 49,
+        totalSessions: 50,
+      },
+    );
+
+    // The "doer" should have a higher efficiency score than the "talker"
+    expect(doer.efficiencyScore).toBeGreaterThan(talker.efficiencyScore);
+    // Talker's activity can be high (interventions count) but output is low
+    expect(talker.outputScore).toBeLessThan(doer.outputScore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Core calculator
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator.calculate', () => {
+  it('should return a complete EfficiencyScore for typical input', () => {
+    const result = EfficiencyScoreCalculator.calculate(
+      typicalActivity,
+      typicalOutput,
+    );
+
+    expect(result).toHaveProperty('activityScore');
+    expect(result).toHaveProperty('outputScore');
+    expect(result).toHaveProperty('efficiencyRatio');
+    expect(result).toHaveProperty('efficiencyScore');
+    expect(result).toHaveProperty('grade');
+    expect(result).toHaveProperty('label');
+
+    // All scores should be within 0–100
+    expect(result.activityScore).toBeGreaterThanOrEqual(0);
+    expect(result.activityScore).toBeLessThanOrEqual(100);
+    expect(result.outputScore).toBeGreaterThanOrEqual(0);
+    expect(result.outputScore).toBeLessThanOrEqual(100);
+    expect(result.efficiencyScore).toBeGreaterThanOrEqual(0);
+    expect(result.efficiencyScore).toBeLessThanOrEqual(100);
+  });
+
+  it('should handle a perfectly balanced deputy (output ≈ activity)', () => {
+    // Create input where output score ≈ activity score
+    const result = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 85,
+        proposalsSubmitted: 10,
+        interventionsMade: 25,
+        questionsAsked: 8,
+      },
+      {
+        votesCast: 450,
+        totalVotes: 500, // 90%
+        sessionsAttended: 45,
+        totalSessions: 50, // 90%
+      },
+    );
+
+    // With 90% output and ~balanced activity, ratio should be around 0.90–1.10
+    expect(result.efficiencyRatio).toBeGreaterThan(0.8);
+    expect(result.efficiencyRatio).toBeLessThan(1.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator — edge cases', () => {
+  it('should return zero efficiency when activity is zero', () => {
+    const result = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 0,
+        proposalsSubmitted: 0,
+        interventionsMade: 0,
+        questionsAsked: 0,
+      },
+      {
+        votesCast: 0,
+        totalVotes: 0,
+        sessionsAttended: 0,
+        totalSessions: 0,
+      },
+    );
+
+    expect(result.activityScore).toBe(0);
+    expect(result.outputScore).toBe(0);
+    expect(result.efficiencyRatio).toBe(0);
+    expect(result.efficiencyScore).toBe(0);
+    expect(result.grade).toBe('F');
+    expect(result.label).toBe(EFFICIENCY_LABELS.minimal);
+  });
+
+  it('should handle zero total votes gracefully (no division by zero)', () => {
+    const result = EfficiencyScoreCalculator.calculate(
+      typicalActivity,
+      {
+        votesCast: 0,
+        totalVotes: 0,
+        sessionsAttended: 0,
+        totalSessions: 0,
+      },
+    );
+
+    expect(result.outputScore).toBe(0);
+    expect(result.efficiencyRatio).toBe(0);
+    expect(result.efficiencyScore).toBe(0);
+  });
+
+  it('should handle zero total sessions gracefully', () => {
+    const result = EfficiencyScoreCalculator.calculate(
+      typicalActivity,
+      {
+        votesCast: 100,
+        totalVotes: 200,
+        sessionsAttended: 0,
+        totalSessions: 0,
+      },
+    );
+
+    // Vote participation contributes 50% of output, session attendance 0%
+    expect(result.outputScore).toBe(25); // (100/200 * 100) * 0.5 = 25
+  });
+
+  it('should cap efficiency score at 100', () => {
+    const result = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 10,
+        proposalsSubmitted: 0,
+        interventionsMade: 0,
+        questionsAsked: 0,
+      },
+      {
+        votesCast: 500,
+        totalVotes: 500,
+        sessionsAttended: 50,
+        totalSessions: 50,
+      },
+    );
+
+    expect(result.efficiencyScore).toBeLessThanOrEqual(100);
+  });
+
+  it('should handle very large numbers without overflow', () => {
+    const result = EfficiencyScoreCalculator.calculate(
+      {
+        attendanceRate: 100,
+        proposalsSubmitted: 10_000,
+        interventionsMade: 10_000,
+        questionsAsked: 10_000,
+      },
+      {
+        votesCast: 1_000_000,
+        totalVotes: 1_000_000,
+        sessionsAttended: 1_000,
+        totalSessions: 1_000,
+      },
+    );
+
+    expect(result.efficiencyScore).toBeGreaterThanOrEqual(0);
+    expect(result.efficiencyScore).toBeLessThanOrEqual(100);
+  });
+
+  it('should not produce NaN for any valid input', () => {
+    const result = EfficiencyScoreCalculator.calculate(
+      { attendanceRate: 50, proposalsSubmitted: 5, interventionsMade: 10, questionsAsked: 3 },
+      { votesCast: 250, totalVotes: 500, sessionsAttended: 25, totalSessions: 50 },
+    );
+
+    expect(Number.isNaN(result.activityScore)).toBe(false);
+    expect(Number.isNaN(result.outputScore)).toBe(false);
+    expect(Number.isNaN(result.efficiencyRatio)).toBe(false);
+    expect(Number.isNaN(result.efficiencyScore)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Weight constants
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator — weight constants', () => {
+  it('should have activity weights that sum to 1.0', () => {
+    const sum =
+      ACTIVITY_WEIGHTS.attendance +
+      ACTIVITY_WEIGHTS.proposals +
+      ACTIVITY_WEIGHTS.interventions +
+      ACTIVITY_WEIGHTS.questions;
+    expect(sum).toBeCloseTo(1.0);
+  });
+
+  it('should have output weights that sum to 1.0', () => {
+    const sum = OUTPUT_WEIGHTS.voteParticipation + OUTPUT_WEIGHTS.sessionAttendance;
+    expect(sum).toBeCloseTo(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grade classification
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator.scoreToGrade', () => {
+  it('should return A for scores at or above the A threshold', () => {
+    expect(EfficiencyScoreCalculator.scoreToGrade(75)).toBe('A');
+    expect(EfficiencyScoreCalculator.scoreToGrade(100)).toBe('A');
+  });
+
+  it('should return B for scores between B and A thresholds', () => {
+    expect(EfficiencyScoreCalculator.scoreToGrade(60)).toBe('B');
+    expect(EfficiencyScoreCalculator.scoreToGrade(74)).toBe('B');
+  });
+
+  it('should return C for scores between C and B thresholds', () => {
+    expect(EfficiencyScoreCalculator.scoreToGrade(45)).toBe('C');
+    expect(EfficiencyScoreCalculator.scoreToGrade(59)).toBe('C');
+  });
+
+  it('should return D for scores between D and C thresholds', () => {
+    expect(EfficiencyScoreCalculator.scoreToGrade(30)).toBe('D');
+    expect(EfficiencyScoreCalculator.scoreToGrade(44)).toBe('D');
+  });
+
+  it('should return F for scores below the D threshold', () => {
+    expect(EfficiencyScoreCalculator.scoreToGrade(0)).toBe('F');
+    expect(EfficiencyScoreCalculator.scoreToGrade(29)).toBe('F');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Label classification
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator.scoreToLabel', () => {
+  it('should return Portuguese labels for each band', () => {
+    expect(EfficiencyScoreCalculator.scoreToLabel(90)).toBe(EFFICIENCY_LABELS.exceptional);
+    expect(EfficiencyScoreCalculator.scoreToLabel(70)).toBe(EFFICIENCY_LABELS.high);
+    expect(EfficiencyScoreCalculator.scoreToLabel(55)).toBe(EFFICIENCY_LABELS.moderate);
+    expect(EfficiencyScoreCalculator.scoreToLabel(40)).toBe(EFFICIENCY_LABELS.low);
+    expect(EfficiencyScoreCalculator.scoreToLabel(10)).toBe(EFFICIENCY_LABELS.minimal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Activity score decomposition
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator — activity score components', () => {
+  it('should weight attendance at 30%', () => {
+    const perfectAttendance = EfficiencyScoreCalculator.calculate(
+      { ...typicalActivity, attendanceRate: 100 },
+      typicalOutput,
+    );
+    const noAttendance = EfficiencyScoreCalculator.calculate(
+      { ...typicalActivity, attendanceRate: 0 },
+      typicalOutput,
+    );
+
+    // 100% attendance contributes 30 raw points (100 * 0.30)
+    const diff = perfectAttendance.activityScore - noAttendance.activityScore;
+    expect(diff).toBeCloseTo(30, -1); // ~30, allowing rounding
+    expect(perfectAttendance.activityScore).toBeGreaterThan(noAttendance.activityScore);
+  });
+
+  it('should weight proposals at 30% (normalized)', () => {
+    const manyProposals = EfficiencyScoreCalculator.calculate(
+      { ...typicalActivity, proposalsSubmitted: 20 }, // 2× baseline → 1.0 norm → 30 pts
+      typicalOutput,
+    );
+    const noProposals = EfficiencyScoreCalculator.calculate(
+      { ...typicalActivity, proposalsSubmitted: 0 },
+      typicalOutput,
+    );
+
+    expect(manyProposals.activityScore).toBeGreaterThan(noProposals.activityScore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration scenario: dashboard API shape
+// ---------------------------------------------------------------------------
+
+describe('EfficiencyScoreCalculator — dashboard API integration', () => {
+  it('should produce a score object with all required fields for the transparency dashboard', () => {
+    const score = EfficiencyScoreCalculator.calculate(
+      typicalActivity,
+      typicalOutput,
+    );
+
+    // Fields expected by the dashboard API consumer
+    expect(typeof score.activityScore).toBe('number');
+    expect(typeof score.outputScore).toBe('number');
+    expect(typeof score.efficiencyRatio).toBe('number');
+    expect(typeof score.efficiencyScore).toBe('number');
+    expect(['A', 'B', 'C', 'D', 'F']).toContain(score.grade);
+    expect(typeof score.label).toBe('string');
+    expect(score.label.length).toBeGreaterThan(0);
+  });
+
+  it('should compute distinct activity and output scores for the same deputy', () => {
+    const score = EfficiencyScoreCalculator.calculate(
+      typicalActivity,
+      typicalOutput,
+    );
+
+    // Activity and output are separate, independently computable dimensions
+    expect(score.activityScore).not.toBe(score.outputScore);
+  });
+});

--- a/apps/web/src/services/metrics/EfficiencyScoreCalculator.test.ts
+++ b/apps/web/src/services/metrics/EfficiencyScoreCalculator.test.ts
@@ -1,15 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
-  EfficiencyScoreCalculator,
   ACTIVITY_WEIGHTS,
   EFFICIENCY_LABELS,
-  EFFICIENCY_THRESHOLDS,
   OUTPUT_WEIGHTS,
+  calculateEfficiencyScore,
+  scoreToGrade,
+  scoreToLabel,
 } from './EfficiencyScoreCalculator';
-import type {
-  ActivityMetrics,
-  OutputMetrics,
-} from './EfficiencyScoreCalculator';
+import type { ActivityMetrics, OutputMetrics } from './EfficiencyScoreCalculator';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -37,7 +35,7 @@ const typicalOutput: OutputMetrics = {
 
 describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
   it('should assign a lower efficiency score when activity is high but output is low', () => {
-    const busyButIneffective = EfficiencyScoreCalculator.calculate(
+    const busyButIneffective = calculateEfficiencyScore(
       {
         attendanceRate: 95,
         proposalsSubmitted: 100,
@@ -49,7 +47,7 @@ describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
         totalVotes: 500,
         sessionsAttended: 10,
         totalSessions: 50,
-      },
+      }
     );
 
     // High activity, low output → efficiency should be low
@@ -60,7 +58,7 @@ describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
   });
 
   it('should assign a higher efficiency score when output matches or exceeds activity norm', () => {
-    const effective = EfficiencyScoreCalculator.calculate(
+    const effective = calculateEfficiencyScore(
       {
         attendanceRate: 80,
         proposalsSubmitted: 8,
@@ -72,7 +70,7 @@ describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
         totalVotes: 500,
         sessionsAttended: 48,
         totalSessions: 50,
-      },
+      }
     );
 
     // Moderate activity, high output → efficiency should be high
@@ -83,7 +81,7 @@ describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
   });
 
   it('should distinguish a "talker" (high interventions) from a "doer" (high vote participation)', () => {
-    const talker = EfficiencyScoreCalculator.calculate(
+    const talker = calculateEfficiencyScore(
       {
         attendanceRate: 70,
         proposalsSubmitted: 5,
@@ -95,10 +93,10 @@ describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
         totalVotes: 500,
         sessionsAttended: 20,
         totalSessions: 50,
-      },
+      }
     );
 
-    const doer = EfficiencyScoreCalculator.calculate(
+    const doer = calculateEfficiencyScore(
       {
         attendanceRate: 90,
         proposalsSubmitted: 15,
@@ -110,7 +108,7 @@ describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
         totalVotes: 500,
         sessionsAttended: 49,
         totalSessions: 50,
-      },
+      }
     );
 
     // The "doer" should have a higher efficiency score than the "talker"
@@ -124,12 +122,9 @@ describe('EfficiencyScoreCalculator — activity vs output distinction', () => {
 // Core calculator
 // ---------------------------------------------------------------------------
 
-describe('EfficiencyScoreCalculator.calculate', () => {
+describe('calculateEfficiencyScore', () => {
   it('should return a complete EfficiencyScore for typical input', () => {
-    const result = EfficiencyScoreCalculator.calculate(
-      typicalActivity,
-      typicalOutput,
-    );
+    const result = calculateEfficiencyScore(typicalActivity, typicalOutput);
 
     expect(result).toHaveProperty('activityScore');
     expect(result).toHaveProperty('outputScore');
@@ -149,7 +144,7 @@ describe('EfficiencyScoreCalculator.calculate', () => {
 
   it('should handle a perfectly balanced deputy (output ≈ activity)', () => {
     // Create input where output score ≈ activity score
-    const result = EfficiencyScoreCalculator.calculate(
+    const result = calculateEfficiencyScore(
       {
         attendanceRate: 85,
         proposalsSubmitted: 10,
@@ -161,7 +156,7 @@ describe('EfficiencyScoreCalculator.calculate', () => {
         totalVotes: 500, // 90%
         sessionsAttended: 45,
         totalSessions: 50, // 90%
-      },
+      }
     );
 
     // With 90% output and ~balanced activity, ratio should be around 0.90–1.10
@@ -174,9 +169,9 @@ describe('EfficiencyScoreCalculator.calculate', () => {
 // Edge cases
 // ---------------------------------------------------------------------------
 
-describe('EfficiencyScoreCalculator — edge cases', () => {
-  it('should return zero efficiency when activity is zero', () => {
-    const result = EfficiencyScoreCalculator.calculate(
+describe('calculateEfficiencyScore — edge cases', () => {
+  it('should return zero efficiency when all metrics are zero', () => {
+    const result = calculateEfficiencyScore(
       {
         attendanceRate: 0,
         proposalsSubmitted: 0,
@@ -188,7 +183,7 @@ describe('EfficiencyScoreCalculator — edge cases', () => {
         totalVotes: 0,
         sessionsAttended: 0,
         totalSessions: 0,
-      },
+      }
     );
 
     expect(result.activityScore).toBe(0);
@@ -200,15 +195,12 @@ describe('EfficiencyScoreCalculator — edge cases', () => {
   });
 
   it('should handle zero total votes gracefully (no division by zero)', () => {
-    const result = EfficiencyScoreCalculator.calculate(
-      typicalActivity,
-      {
-        votesCast: 0,
-        totalVotes: 0,
-        sessionsAttended: 0,
-        totalSessions: 0,
-      },
-    );
+    const result = calculateEfficiencyScore(typicalActivity, {
+      votesCast: 0,
+      totalVotes: 0,
+      sessionsAttended: 0,
+      totalSessions: 0,
+    });
 
     expect(result.outputScore).toBe(0);
     expect(result.efficiencyRatio).toBe(0);
@@ -216,22 +208,19 @@ describe('EfficiencyScoreCalculator — edge cases', () => {
   });
 
   it('should handle zero total sessions gracefully', () => {
-    const result = EfficiencyScoreCalculator.calculate(
-      typicalActivity,
-      {
-        votesCast: 100,
-        totalVotes: 200,
-        sessionsAttended: 0,
-        totalSessions: 0,
-      },
-    );
+    const result = calculateEfficiencyScore(typicalActivity, {
+      votesCast: 100,
+      totalVotes: 200,
+      sessionsAttended: 0,
+      totalSessions: 0,
+    });
 
     // Vote participation contributes 50% of output, session attendance 0%
     expect(result.outputScore).toBe(25); // (100/200 * 100) * 0.5 = 25
   });
 
   it('should cap efficiency score at 100', () => {
-    const result = EfficiencyScoreCalculator.calculate(
+    const result = calculateEfficiencyScore(
       {
         attendanceRate: 10,
         proposalsSubmitted: 0,
@@ -243,14 +232,14 @@ describe('EfficiencyScoreCalculator — edge cases', () => {
         totalVotes: 500,
         sessionsAttended: 50,
         totalSessions: 50,
-      },
+      }
     );
 
     expect(result.efficiencyScore).toBeLessThanOrEqual(100);
   });
 
   it('should handle very large numbers without overflow', () => {
-    const result = EfficiencyScoreCalculator.calculate(
+    const result = calculateEfficiencyScore(
       {
         attendanceRate: 100,
         proposalsSubmitted: 10_000,
@@ -262,7 +251,7 @@ describe('EfficiencyScoreCalculator — edge cases', () => {
         totalVotes: 1_000_000,
         sessionsAttended: 1_000,
         totalSessions: 1_000,
-      },
+      }
     );
 
     expect(result.efficiencyScore).toBeGreaterThanOrEqual(0);
@@ -270,9 +259,9 @@ describe('EfficiencyScoreCalculator — edge cases', () => {
   });
 
   it('should not produce NaN for any valid input', () => {
-    const result = EfficiencyScoreCalculator.calculate(
+    const result = calculateEfficiencyScore(
       { attendanceRate: 50, proposalsSubmitted: 5, interventionsMade: 10, questionsAsked: 3 },
-      { votesCast: 250, totalVotes: 500, sessionsAttended: 25, totalSessions: 50 },
+      { votesCast: 250, totalVotes: 500, sessionsAttended: 25, totalSessions: 50 }
     );
 
     expect(Number.isNaN(result.activityScore)).toBe(false);
@@ -286,7 +275,7 @@ describe('EfficiencyScoreCalculator — edge cases', () => {
 // Weight constants
 // ---------------------------------------------------------------------------
 
-describe('EfficiencyScoreCalculator — weight constants', () => {
+describe('weight constants', () => {
   it('should have activity weights that sum to 1.0', () => {
     const sum =
       ACTIVITY_WEIGHTS.attendance +
@@ -306,30 +295,30 @@ describe('EfficiencyScoreCalculator — weight constants', () => {
 // Grade classification
 // ---------------------------------------------------------------------------
 
-describe('EfficiencyScoreCalculator.scoreToGrade', () => {
+describe('scoreToGrade', () => {
   it('should return A for scores at or above the A threshold', () => {
-    expect(EfficiencyScoreCalculator.scoreToGrade(75)).toBe('A');
-    expect(EfficiencyScoreCalculator.scoreToGrade(100)).toBe('A');
+    expect(scoreToGrade(75)).toBe('A');
+    expect(scoreToGrade(100)).toBe('A');
   });
 
   it('should return B for scores between B and A thresholds', () => {
-    expect(EfficiencyScoreCalculator.scoreToGrade(60)).toBe('B');
-    expect(EfficiencyScoreCalculator.scoreToGrade(74)).toBe('B');
+    expect(scoreToGrade(60)).toBe('B');
+    expect(scoreToGrade(74)).toBe('B');
   });
 
   it('should return C for scores between C and B thresholds', () => {
-    expect(EfficiencyScoreCalculator.scoreToGrade(45)).toBe('C');
-    expect(EfficiencyScoreCalculator.scoreToGrade(59)).toBe('C');
+    expect(scoreToGrade(45)).toBe('C');
+    expect(scoreToGrade(59)).toBe('C');
   });
 
   it('should return D for scores between D and C thresholds', () => {
-    expect(EfficiencyScoreCalculator.scoreToGrade(30)).toBe('D');
-    expect(EfficiencyScoreCalculator.scoreToGrade(44)).toBe('D');
+    expect(scoreToGrade(30)).toBe('D');
+    expect(scoreToGrade(44)).toBe('D');
   });
 
   it('should return F for scores below the D threshold', () => {
-    expect(EfficiencyScoreCalculator.scoreToGrade(0)).toBe('F');
-    expect(EfficiencyScoreCalculator.scoreToGrade(29)).toBe('F');
+    expect(scoreToGrade(0)).toBe('F');
+    expect(scoreToGrade(29)).toBe('F');
   });
 });
 
@@ -337,13 +326,13 @@ describe('EfficiencyScoreCalculator.scoreToGrade', () => {
 // Label classification
 // ---------------------------------------------------------------------------
 
-describe('EfficiencyScoreCalculator.scoreToLabel', () => {
+describe('scoreToLabel', () => {
   it('should return Portuguese labels for each band', () => {
-    expect(EfficiencyScoreCalculator.scoreToLabel(90)).toBe(EFFICIENCY_LABELS.exceptional);
-    expect(EfficiencyScoreCalculator.scoreToLabel(70)).toBe(EFFICIENCY_LABELS.high);
-    expect(EfficiencyScoreCalculator.scoreToLabel(55)).toBe(EFFICIENCY_LABELS.moderate);
-    expect(EfficiencyScoreCalculator.scoreToLabel(40)).toBe(EFFICIENCY_LABELS.low);
-    expect(EfficiencyScoreCalculator.scoreToLabel(10)).toBe(EFFICIENCY_LABELS.minimal);
+    expect(scoreToLabel(90)).toBe(EFFICIENCY_LABELS.exceptional);
+    expect(scoreToLabel(70)).toBe(EFFICIENCY_LABELS.high);
+    expect(scoreToLabel(55)).toBe(EFFICIENCY_LABELS.moderate);
+    expect(scoreToLabel(40)).toBe(EFFICIENCY_LABELS.low);
+    expect(scoreToLabel(10)).toBe(EFFICIENCY_LABELS.minimal);
   });
 });
 
@@ -351,15 +340,15 @@ describe('EfficiencyScoreCalculator.scoreToLabel', () => {
 // Activity score decomposition
 // ---------------------------------------------------------------------------
 
-describe('EfficiencyScoreCalculator — activity score components', () => {
+describe('EfficiencyScore — activity score components', () => {
   it('should weight attendance at 30%', () => {
-    const perfectAttendance = EfficiencyScoreCalculator.calculate(
+    const perfectAttendance = calculateEfficiencyScore(
       { ...typicalActivity, attendanceRate: 100 },
-      typicalOutput,
+      typicalOutput
     );
-    const noAttendance = EfficiencyScoreCalculator.calculate(
+    const noAttendance = calculateEfficiencyScore(
       { ...typicalActivity, attendanceRate: 0 },
-      typicalOutput,
+      typicalOutput
     );
 
     // 100% attendance contributes 30 raw points (100 * 0.30)
@@ -369,13 +358,13 @@ describe('EfficiencyScoreCalculator — activity score components', () => {
   });
 
   it('should weight proposals at 30% (normalized)', () => {
-    const manyProposals = EfficiencyScoreCalculator.calculate(
+    const manyProposals = calculateEfficiencyScore(
       { ...typicalActivity, proposalsSubmitted: 20 }, // 2× baseline → 1.0 norm → 30 pts
-      typicalOutput,
+      typicalOutput
     );
-    const noProposals = EfficiencyScoreCalculator.calculate(
+    const noProposals = calculateEfficiencyScore(
       { ...typicalActivity, proposalsSubmitted: 0 },
-      typicalOutput,
+      typicalOutput
     );
 
     expect(manyProposals.activityScore).toBeGreaterThan(noProposals.activityScore);
@@ -386,12 +375,9 @@ describe('EfficiencyScoreCalculator — activity score components', () => {
 // Integration scenario: dashboard API shape
 // ---------------------------------------------------------------------------
 
-describe('EfficiencyScoreCalculator — dashboard API integration', () => {
+describe('calculateEfficiencyScore — dashboard API integration', () => {
   it('should produce a score object with all required fields for the transparency dashboard', () => {
-    const score = EfficiencyScoreCalculator.calculate(
-      typicalActivity,
-      typicalOutput,
-    );
+    const score = calculateEfficiencyScore(typicalActivity, typicalOutput);
 
     // Fields expected by the dashboard API consumer
     expect(typeof score.activityScore).toBe('number');
@@ -404,10 +390,7 @@ describe('EfficiencyScoreCalculator — dashboard API integration', () => {
   });
 
   it('should compute distinct activity and output scores for the same deputy', () => {
-    const score = EfficiencyScoreCalculator.calculate(
-      typicalActivity,
-      typicalOutput,
-    );
+    const score = calculateEfficiencyScore(typicalActivity, typicalOutput);
 
     // Activity and output are separate, independently computable dimensions
     expect(score.activityScore).not.toBe(score.outputScore);

--- a/apps/web/src/services/metrics/EfficiencyScoreCalculator.ts
+++ b/apps/web/src/services/metrics/EfficiencyScoreCalculator.ts
@@ -55,16 +55,16 @@ export interface OutputMetrics {
 
 /** Weights for activity components (must sum to 1.0). */
 export const ACTIVITY_WEIGHTS = {
-  attendance: 0.30,
-  proposals: 0.30,
+  attendance: 0.3,
+  proposals: 0.3,
   interventions: 0.25,
   questions: 0.15,
 } as const;
 
 /** Weights for output components (must sum to 1.0). */
 export const OUTPUT_WEIGHTS = {
-  voteParticipation: 0.50,
-  sessionAttendance: 0.50,
+  voteParticipation: 0.5,
+  sessionAttendance: 0.5,
 } as const;
 
 /** Human-readable labels keyed by efficiency score band. */
@@ -103,117 +103,115 @@ export interface EfficiencyScore {
 }
 
 // ---------------------------------------------------------------------------
-// Calculator
+// Helpers
 // ---------------------------------------------------------------------------
 
-export class EfficiencyScoreCalculator {
-  /**
-   * Compute the full efficiency score from raw activity + output data.
-   *
-   * All numeric inputs must be non-negative. The calculator handles zero
-   * activity gracefully (returns 0 efficiency).
-   */
-  static calculate(activity: ActivityMetrics, output: OutputMetrics): EfficiencyScore {
-    const activityScore = EfficiencyScoreCalculator.computeActivityScore(activity);
-    const outputScore = EfficiencyScoreCalculator.computeOutputScore(output);
-    const efficiencyRatio =
-      activityScore > 0 ? outputScore / activityScore : 0;
+/**
+ * Normalize a raw count to a 0–1 scale using a baseline average.
+ *
+ * A deputy at the baseline gets ~0.5. Twice the baseline → 1.0.
+ * Zero counts → 0. This prevents outlier deputies from skewing
+ * the score too heavily.
+ */
+function normalizeCount(value: number, baseline: number): number {
+  if (baseline <= 0) return 0;
+  return Math.min(value / (baseline * 2), 1);
+}
 
-    // Scale so that ratio 1.0 maps to 50 (balanced), max 2.0 → 100
-    const efficiencyScore = Math.min(Math.round(efficiencyRatio * 50), 100);
+/**
+ * Compute the aggregate activity score (0–100).
+ *
+ * Each metric is normalised so the deputy-level average maps to 50,
+ * individual metrics are then weighted and summed.
+ */
+function computeActivityScore(metrics: ActivityMetrics): number {
+  // Normalize counts: use a baseline where "average" is ~50 points.
+  // These baselines represent a typical active deputy in the Portuguese
+  // Parliament over one legislative session.
+  const normProposals = normalizeCount(
+    metrics.proposalsSubmitted,
+    10 // baseline average proposals
+  );
+  const normInterventions = normalizeCount(
+    metrics.interventionsMade,
+    25 // baseline average interventions
+  );
+  const normQuestions = normalizeCount(
+    metrics.questionsAsked,
+    8 // baseline average questions
+  );
 
-    return {
-      activityScore: Math.round(activityScore),
-      outputScore: Math.round(outputScore),
-      efficiencyRatio: Math.round(efficiencyRatio * 100) / 100,
-      efficiencyScore,
-      grade: EfficiencyScoreCalculator.scoreToGrade(efficiencyScore),
-      label: EfficiencyScoreCalculator.scoreToLabel(efficiencyScore),
-    };
-  }
+  return (
+    metrics.attendanceRate * ACTIVITY_WEIGHTS.attendance +
+    normProposals * ACTIVITY_WEIGHTS.proposals * 100 +
+    normInterventions * ACTIVITY_WEIGHTS.interventions * 100 +
+    normQuestions * ACTIVITY_WEIGHTS.questions * 100
+  );
+}
 
-  // -- internal helpers ----------------------------------------------------
+/**
+ * Compute the aggregate output score (0–100).
+ */
+function computeOutputScore(metrics: OutputMetrics): number {
+  // Vote participation rate (0–100)
+  const voteParticipation =
+    metrics.totalVotes > 0 ? (metrics.votesCast / metrics.totalVotes) * 100 : 0;
 
-  /**
-   * Compute the aggregate activity score (0–100).
-   *
-   * Each metric is normalised so the deputy-level average maps to 50,
-   * individual metrics are then weighted and summed.
-   */
-  private static computeActivityScore(metrics: ActivityMetrics): number {
-    // Normalize counts: use a baseline where "average" is ~50 points.
-    // These baselines represent a typical active deputy in the Portuguese
-    // Parliament over one legislative session.
-    const normProposals = EfficiencyScoreCalculator.normalizeCount(
-      metrics.proposalsSubmitted,
-      10, // baseline average proposals
-    );
-    const normInterventions = EfficiencyScoreCalculator.normalizeCount(
-      metrics.interventionsMade,
-      25, // baseline average interventions
-    );
-    const normQuestions = EfficiencyScoreCalculator.normalizeCount(
-      metrics.questionsAsked,
-      8, // baseline average questions
-    );
+  // Session attendance rate (0–100)
+  const sessionAttendance =
+    metrics.totalSessions > 0 ? (metrics.sessionsAttended / metrics.totalSessions) * 100 : 0;
 
-    return (
-      metrics.attendanceRate * ACTIVITY_WEIGHTS.attendance +
-      normProposals * ACTIVITY_WEIGHTS.proposals * 100 +
-      normInterventions * ACTIVITY_WEIGHTS.interventions * 100 +
-      normQuestions * ACTIVITY_WEIGHTS.questions * 100
-    );
-  }
+  return (
+    voteParticipation * OUTPUT_WEIGHTS.voteParticipation +
+    sessionAttendance * OUTPUT_WEIGHTS.sessionAttendance
+  );
+}
 
-  /**
-   * Compute the aggregate output score (0–100).
-   */
-  private static computeOutputScore(metrics: OutputMetrics): number {
-    // Vote participation rate (0–100)
-    const voteParticipation =
-      metrics.totalVotes > 0
-        ? (metrics.votesCast / metrics.totalVotes) * 100
-        : 0;
+/** Map a 0–100 score to a letter grade. */
+export function scoreToGrade(score: number): EfficiencyGrade {
+  if (score >= EFFICIENCY_THRESHOLDS.A) return 'A';
+  if (score >= EFFICIENCY_THRESHOLDS.B) return 'B';
+  if (score >= EFFICIENCY_THRESHOLDS.C) return 'C';
+  if (score >= EFFICIENCY_THRESHOLDS.D) return 'D';
+  return 'F';
+}
 
-    // Session attendance rate (0–100)
-    const sessionAttendance =
-      metrics.totalSessions > 0
-        ? (metrics.sessionsAttended / metrics.totalSessions) * 100
-        : 0;
+/** Map a 0–100 score to a Portuguese-language label. */
+export function scoreToLabel(score: number): string {
+  if (score >= 75) return EFFICIENCY_LABELS.exceptional;
+  if (score >= 60) return EFFICIENCY_LABELS.high;
+  if (score >= 45) return EFFICIENCY_LABELS.moderate;
+  if (score >= 30) return EFFICIENCY_LABELS.low;
+  return EFFICIENCY_LABELS.minimal;
+}
 
-    return (
-      voteParticipation * OUTPUT_WEIGHTS.voteParticipation +
-      sessionAttendance * OUTPUT_WEIGHTS.sessionAttendance
-    );
-  }
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
-  /**
-   * Normalize a raw count to a 0–1 scale using a baseline average.
-   *
-   * A deputy at the baseline gets ~0.5. Twice the baseline → 1.0.
-   * Zero counts → 0. This prevents outlier deputies from skewing
-   * the score too heavily.
-   */
-  private static normalizeCount(value: number, baseline: number): number {
-    if (baseline <= 0) return 0;
-    return Math.min(value / (baseline * 2), 1);
-  }
+/**
+ * Compute the full efficiency score from raw activity + output data.
+ *
+ * All numeric inputs must be non-negative. The calculator handles zero
+ * activity gracefully (returns 0 efficiency).
+ */
+export function calculateEfficiencyScore(
+  activity: ActivityMetrics,
+  output: OutputMetrics
+): EfficiencyScore {
+  const activityScore = computeActivityScore(activity);
+  const outputScore = computeOutputScore(output);
+  const efficiencyRatio = activityScore > 0 ? outputScore / activityScore : 0;
 
-  /** Map a 0–100 score to a letter grade. */
-  static scoreToGrade(score: number): EfficiencyGrade {
-    if (score >= EFFICIENCY_THRESHOLDS.A) return 'A';
-    if (score >= EFFICIENCY_THRESHOLDS.B) return 'B';
-    if (score >= EFFICIENCY_THRESHOLDS.C) return 'C';
-    if (score >= EFFICIENCY_THRESHOLDS.D) return 'D';
-    return 'F';
-  }
+  // Scale so that ratio 1.0 maps to 50 (balanced), max 2.0 → 100
+  const efficiencyScore = Math.min(Math.round(efficiencyRatio * 50), 100);
 
-  /** Map a 0–100 score to a Portuguese-language label. */
-  static scoreToLabel(score: number): string {
-    if (score >= 75) return EFFICIENCY_LABELS.exceptional;
-    if (score >= 60) return EFFICIENCY_LABELS.high;
-    if (score >= 45) return EFFICIENCY_LABELS.moderate;
-    if (score >= 30) return EFFICIENCY_LABELS.low;
-    return EFFICIENCY_LABELS.minimal;
-  }
+  return {
+    activityScore: Math.round(activityScore),
+    outputScore: Math.round(outputScore),
+    efficiencyRatio: Math.round(efficiencyRatio * 100) / 100,
+    efficiencyScore,
+    grade: scoreToGrade(efficiencyScore),
+    label: scoreToLabel(efficiencyScore),
+  };
 }

--- a/apps/web/src/services/metrics/EfficiencyScoreCalculator.ts
+++ b/apps/web/src/services/metrics/EfficiencyScoreCalculator.ts
@@ -1,0 +1,219 @@
+/**
+ * Legislative Efficiency Score Calculator
+ *
+ * Distinguishes between parliamentary "activity" (what deputies do) and
+ * "output" (what deputies achieve). The efficiency score measures how much
+ * legislative result a deputy produces per unit of activity.
+ *
+ * ## Concepts
+ *
+ * **Activity** = raw input volume: proposals submitted, interventions made,
+ *   questions asked, attendance
+ *
+ * **Output** = legislative results: votes cast (decision-making participation),
+ *   consistent plenary attendance (being present when it matters)
+ *
+ * ## Formula
+ *
+ *   ActivityScore = normalized average of all activity metrics (0–100)
+ *   OutputScore   = weighted output metrics (0–100)
+ *   Efficiency    = OutputScore / max(ActivityScore, 1) — ratio of output to input
+ *   FinalScore    = clamp(Efficiency * 50, 0, 100)
+ *
+ * A score of 50 means output matches activity (1:1). Above 50 means the deputy
+ * achieves more output relative to activity. Below 50 means activity exceeds
+ * results — high motion, low impact.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Raw activity metrics — what a deputy *does* (input). */
+export interface ActivityMetrics {
+  /** Percentage of plenary sessions attended (0–100). */
+  attendanceRate: number;
+  /** Number of legislative proposals authored or co-authored. */
+  proposalsSubmitted: number;
+  /** Number of parliamentary interventions (speeches, debates). */
+  interventionsMade: number;
+  /** Number of written questions submitted to the government. */
+  questionsAsked: number;
+}
+
+/** Output metrics — what a deputy *achieves* (results). */
+export interface OutputMetrics {
+  /** Votes actually cast out of total possible votes. */
+  votesCast: number;
+  /** Total votes the deputy could have participated in. */
+  totalVotes: number;
+  /** Number of plenary sessions attended. */
+  sessionsAttended: number;
+  /** Total plenary sessions held. */
+  totalSessions: number;
+}
+
+/** Weights for activity components (must sum to 1.0). */
+export const ACTIVITY_WEIGHTS = {
+  attendance: 0.30,
+  proposals: 0.30,
+  interventions: 0.25,
+  questions: 0.15,
+} as const;
+
+/** Weights for output components (must sum to 1.0). */
+export const OUTPUT_WEIGHTS = {
+  voteParticipation: 0.50,
+  sessionAttendance: 0.50,
+} as const;
+
+/** Human-readable labels keyed by efficiency score band. */
+export const EFFICIENCY_LABELS = {
+  exceptional: 'Excecional',
+  high: 'Elevada',
+  moderate: 'Moderada',
+  low: 'Baixa',
+  minimal: 'Mínima',
+} as const;
+
+/** Grade thresholds for the efficiency score. */
+export const EFFICIENCY_THRESHOLDS = {
+  A: 75,
+  B: 60,
+  C: 45,
+  D: 30,
+  F: 0,
+} as const;
+
+export type EfficiencyGrade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+export interface EfficiencyScore {
+  /** Computed activity score (0–100). */
+  activityScore: number;
+  /** Computed output score (0–100). */
+  outputScore: number;
+  /** Output-to-activity ratio (0–2+). */
+  efficiencyRatio: number;
+  /** Final efficiency score (0–100). */
+  efficiencyScore: number;
+  /** Letter grade derived from the efficiency score. */
+  grade: EfficiencyGrade;
+  /** Human-readable label for the score band. */
+  label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Calculator
+// ---------------------------------------------------------------------------
+
+export class EfficiencyScoreCalculator {
+  /**
+   * Compute the full efficiency score from raw activity + output data.
+   *
+   * All numeric inputs must be non-negative. The calculator handles zero
+   * activity gracefully (returns 0 efficiency).
+   */
+  static calculate(activity: ActivityMetrics, output: OutputMetrics): EfficiencyScore {
+    const activityScore = EfficiencyScoreCalculator.computeActivityScore(activity);
+    const outputScore = EfficiencyScoreCalculator.computeOutputScore(output);
+    const efficiencyRatio =
+      activityScore > 0 ? outputScore / activityScore : 0;
+
+    // Scale so that ratio 1.0 maps to 50 (balanced), max 2.0 → 100
+    const efficiencyScore = Math.min(Math.round(efficiencyRatio * 50), 100);
+
+    return {
+      activityScore: Math.round(activityScore),
+      outputScore: Math.round(outputScore),
+      efficiencyRatio: Math.round(efficiencyRatio * 100) / 100,
+      efficiencyScore,
+      grade: EfficiencyScoreCalculator.scoreToGrade(efficiencyScore),
+      label: EfficiencyScoreCalculator.scoreToLabel(efficiencyScore),
+    };
+  }
+
+  // -- internal helpers ----------------------------------------------------
+
+  /**
+   * Compute the aggregate activity score (0–100).
+   *
+   * Each metric is normalised so the deputy-level average maps to 50,
+   * individual metrics are then weighted and summed.
+   */
+  private static computeActivityScore(metrics: ActivityMetrics): number {
+    // Normalize counts: use a baseline where "average" is ~50 points.
+    // These baselines represent a typical active deputy in the Portuguese
+    // Parliament over one legislative session.
+    const normProposals = EfficiencyScoreCalculator.normalizeCount(
+      metrics.proposalsSubmitted,
+      10, // baseline average proposals
+    );
+    const normInterventions = EfficiencyScoreCalculator.normalizeCount(
+      metrics.interventionsMade,
+      25, // baseline average interventions
+    );
+    const normQuestions = EfficiencyScoreCalculator.normalizeCount(
+      metrics.questionsAsked,
+      8, // baseline average questions
+    );
+
+    return (
+      metrics.attendanceRate * ACTIVITY_WEIGHTS.attendance +
+      normProposals * ACTIVITY_WEIGHTS.proposals * 100 +
+      normInterventions * ACTIVITY_WEIGHTS.interventions * 100 +
+      normQuestions * ACTIVITY_WEIGHTS.questions * 100
+    );
+  }
+
+  /**
+   * Compute the aggregate output score (0–100).
+   */
+  private static computeOutputScore(metrics: OutputMetrics): number {
+    // Vote participation rate (0–100)
+    const voteParticipation =
+      metrics.totalVotes > 0
+        ? (metrics.votesCast / metrics.totalVotes) * 100
+        : 0;
+
+    // Session attendance rate (0–100)
+    const sessionAttendance =
+      metrics.totalSessions > 0
+        ? (metrics.sessionsAttended / metrics.totalSessions) * 100
+        : 0;
+
+    return (
+      voteParticipation * OUTPUT_WEIGHTS.voteParticipation +
+      sessionAttendance * OUTPUT_WEIGHTS.sessionAttendance
+    );
+  }
+
+  /**
+   * Normalize a raw count to a 0–1 scale using a baseline average.
+   *
+   * A deputy at the baseline gets ~0.5. Twice the baseline → 1.0.
+   * Zero counts → 0. This prevents outlier deputies from skewing
+   * the score too heavily.
+   */
+  private static normalizeCount(value: number, baseline: number): number {
+    if (baseline <= 0) return 0;
+    return Math.min(value / (baseline * 2), 1);
+  }
+
+  /** Map a 0–100 score to a letter grade. */
+  static scoreToGrade(score: number): EfficiencyGrade {
+    if (score >= EFFICIENCY_THRESHOLDS.A) return 'A';
+    if (score >= EFFICIENCY_THRESHOLDS.B) return 'B';
+    if (score >= EFFICIENCY_THRESHOLDS.C) return 'C';
+    if (score >= EFFICIENCY_THRESHOLDS.D) return 'D';
+    return 'F';
+  }
+
+  /** Map a 0–100 score to a Portuguese-language label. */
+  static scoreToLabel(score: number): string {
+    if (score >= 75) return EFFICIENCY_LABELS.exceptional;
+    if (score >= 60) return EFFICIENCY_LABELS.high;
+    if (score >= 45) return EFFICIENCY_LABELS.moderate;
+    if (score >= 30) return EFFICIENCY_LABELS.low;
+    return EFFICIENCY_LABELS.minimal;
+  }
+}

--- a/apps/web/src/services/metrics/index.ts
+++ b/apps/web/src/services/metrics/index.ts
@@ -1,5 +1,7 @@
 export {
-  EfficiencyScoreCalculator,
+  calculateEfficiencyScore,
+  scoreToGrade,
+  scoreToLabel,
   ACTIVITY_WEIGHTS,
   OUTPUT_WEIGHTS,
   EFFICIENCY_LABELS,

--- a/apps/web/src/services/metrics/index.ts
+++ b/apps/web/src/services/metrics/index.ts
@@ -1,0 +1,14 @@
+export {
+  EfficiencyScoreCalculator,
+  ACTIVITY_WEIGHTS,
+  OUTPUT_WEIGHTS,
+  EFFICIENCY_LABELS,
+  EFFICIENCY_THRESHOLDS,
+} from './EfficiencyScoreCalculator';
+
+export type {
+  ActivityMetrics,
+  OutputMetrics,
+  EfficiencyScore,
+  EfficiencyGrade,
+} from './EfficiencyScoreCalculator';


### PR DESCRIPTION
## Summary

Adds a **Legislative Efficiency Score** (`calculateEfficiencyScore`) to the Adamastor transparency platform.

The metric distinguishes parliamentary **activity** (proposals submitted, interventions made, questions asked, attendance) from **output** (vote participation, session attendance) and assigns a qualitative Portuguese-language grade, providing deeper assessment beyond raw activity counts.

## Changes

- `apps/web/src/services/metrics/EfficiencyScoreCalculator.ts` — Core calculator with types (`ActivityMetrics`, `OutputMetrics`, `EfficiencyScore`, `EfficiencyGrade`), exported weight constants, and helper functions (`calculateEfficiencyScore`, `scoreToGrade`, `scoreToLabel`).
- `apps/web/src/services/metrics/EfficiencyScoreCalculator.test.ts` — 23 unit tests covering normal ranges, edge cases (zero, max, missing data), division-by-zero safety, NaN safety, weight validation, grade classification, label classification, and activity-vs-output distinction.

## Design Decisions

- **Plain functions, not a static class** — per Biome lint rule `noStaticOnlyClass`.
- **Portuguese labels** for grades (Excecional, Elevada, Moderada, Baixa, Mínima).
- **Output/Activity ratio** scaled so 1:1 maps to 50 (balanced), >1 gets higher efficiency.
- All weights exported as `as const` for downstream reuse.