### PR TITLE
feat: add monthly performance trajectory visualization (BRU-882)

### DIFF
--- a/apps/web/src/components/ReportCard/MetricTrajectory.test.tsx
+++ b/apps/web/src/components/ReportCard/MetricTrajectory.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MetricTrajectory } from './MetricTrajectory';
+import { MetricsTrajectoryPanel } from './MetricsTrajectoryPanel';
+import type { MonthlyDataPoint } from './MetricTrajectory';
+
+const mockData: MonthlyDataPoint[] = [
+  { month: 'Jan', value: 10 },
+  { month: 'Fev', value: 15 },
+  { month: 'Mar', value: 25 },
+  { month: 'Abr', value: 20 },
+];
+
+const flatData: MonthlyDataPoint[] = [
+  { month: 'Jan', value: 50 },
+  { month: 'Fev', value: 50 },
+  { month: 'Mar', value: 50 },
+];
+
+const twoPointData: MonthlyDataPoint[] = [
+  { month: 'Jan', value: 10 },
+  { month: 'Fev', value: 20 },
+];
+
+describe('MetricTrajectory', () => {
+  it('should render the metric label', () => {
+    render(<MetricTrajectory label="Propostas" data={mockData} />);
+    expect(screen.getByText('Propostas')).toBeTruthy();
+  });
+
+  it('should render an SVG element', () => {
+    const { container } = render(<MetricTrajectory label="Teste" data={mockData} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
+
+  it('should render data point circles', () => {
+    const { container } = render(<MetricTrajectory label="Teste" data={mockData} />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(4);
+  });
+
+  it('should show first and last month in the legend', () => {
+    render(<MetricTrajectory label="Teste" data={mockData} />);
+    expect(screen.getByText(/Jan 10/)).toBeTruthy();
+    expect(screen.getByText(/Abr 20/)).toBeTruthy();
+  });
+
+  it('should format percentage values with %', () => {
+    const pctData: MonthlyDataPoint[] = [
+      { month: 'Jan', value: 60 },
+      { month: 'Fev', value: 75 },
+    ];
+    render(<MetricTrajectory label="Presença" data={pctData} isPercentage={true} />);
+    expect(screen.getByText(/Jan 60%/)).toBeTruthy();
+    expect(screen.getByText(/Fev 75%/)).toBeTruthy();
+  });
+
+  it('should render with less than 2 data points (return null)', () => {
+    const { container } = render(
+      <MetricTrajectory label="Vazio" data={[{ month: 'Jan', value: 10 }]} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should render with exactly 2 data points', () => {
+    render(<MetricTrajectory label="Minimo" data={twoPointData} />);
+    expect(screen.getByText('Minimo')).toBeTruthy();
+  });
+
+  it('should render a trend icon for upward trend', () => {
+    const { container } = render(<MetricTrajectory label="Subindo" data={twoPointData} />);
+    // last > first, so trend is 'up' -> TrendingUp icon
+    const icons = container.querySelectorAll('svg');
+    expect(icons.length).toBeGreaterThanOrEqual(1); // at least the chart SVG + possibly trend icon
+  });
+
+  it('should render flat data without trend icon', () => {
+    const { container } = render(<MetricTrajectory label="Plano" data={flatData} />);
+    const svgCount = container.querySelectorAll('svg').length;
+    // Should only have the chart SVG (no trend icon when flat)
+    expect(svgCount).toBe(1);
+  });
+
+  it('should have accessible title on data points', () => {
+    const { container } = render(<MetricTrajectory label="Teste" data={mockData} />);
+    const circles = container.querySelectorAll('circle');
+    const firstCircle = circles[0];
+    const title = firstCircle?.querySelector('title');
+    expect(title?.textContent).toBe('Jan: 10');
+  });
+
+  it('should render line path element when data has 2+ points', () => {
+    const { container } = render(<MetricTrajectory label="Teste" data={twoPointData} />);
+    const path = container.querySelector('path');
+    expect(path).toBeTruthy();
+  });
+});
+
+describe('MetricsTrajectoryPanel', () => {
+  it('should render section title', () => {
+    render(
+      <MetricsTrajectoryPanel
+        metrics={[{ label: 'Teste', data: mockData }]}
+      />,
+    );
+    expect(screen.getByText('Evolução Mensal')).toBeTruthy();
+  });
+
+  it('should render multiple metrics', () => {
+    render(
+      <MetricsTrajectoryPanel
+        metrics={[
+          { label: 'Propostas', data: mockData },
+          { label: 'Intervenções', data: twoPointData },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Propostas')).toBeTruthy();
+    expect(screen.getByText('Intervenções')).toBeTruthy();
+  });
+
+  it('should return null with empty metrics array', () => {
+    const { container } = render(<MetricsTrajectoryPanel metrics={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should return null with undefined metrics', () => {
+    const { container } = render(<MetricsTrajectoryPanel metrics={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should accept custom title', () => {
+    render(
+      <MetricsTrajectoryPanel
+        title="Trajetória Customizada"
+        metrics={[{ label: 'Teste', data: mockData }]}
+      />,
+    );
+    expect(screen.getByText('Trajetória Customizada')).toBeTruthy();
+  });
+
+  it('should render isPercentage metrics', () => {
+    const pctData: MonthlyDataPoint[] = [
+      { month: 'Jan', value: 60 },
+      { month: 'Fev', value: 75 },
+    ];
+    render(
+      <MetricsTrajectoryPanel
+        metrics={[{ label: 'Presença', data: pctData, isPercentage: true, color: 'success' }]}
+      />,
+    );
+    expect(screen.getByText('Presença')).toBeTruthy();
+    expect(screen.getByText(/Jan 60%/)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/ReportCard/MetricTrajectory.tsx
+++ b/apps/web/src/components/ReportCard/MetricTrajectory.tsx
@@ -18,7 +18,7 @@ const PAD = 4;
 
 function linePath(data: MonthlyDataPoint[], xScale: number, yScale: number, min: number): string {
   return data
-    .map((d, i) => `${i === 0 ? 'M' : 'L'}${i * xScale + PAD},${min - (d.value - min) * yScale + PAD}`)
+    .map((d, i) => `${i === 0 ? 'M' : 'L'}${i * xScale + PAD},${CHART_HEIGHT - PAD - (d.value - min) * yScale}`)
     .join(' ');
 }
 
@@ -112,7 +112,7 @@ export function MetricTrajectory({
           <circle
             key={d.month}
             cx={i * xScale + PAD}
-            cy={min - (d.value - min) * yScale + PAD}
+            cy={CHART_HEIGHT - PAD - (d.value - min) * yScale}
             r={3}
             className={`${fillMap[color]} stroke-neutral-1`}
             strokeWidth={1.5}

--- a/apps/web/src/components/ReportCard/MetricTrajectory.tsx
+++ b/apps/web/src/components/ReportCard/MetricTrajectory.tsx
@@ -1,0 +1,148 @@
+import { TrendingDown, TrendingUp } from 'lucide-react';
+
+export interface MonthlyDataPoint {
+  month: string;
+  value: number;
+}
+
+interface MetricTrajectoryProps {
+  label: string;
+  data: MonthlyDataPoint[];
+  isPercentage?: boolean;
+  color?: 'accent' | 'success' | 'warning' | 'danger';
+}
+
+const CHART_WIDTH = 240;
+const CHART_HEIGHT = 80;
+const PAD = 4;
+
+function linePath(data: MonthlyDataPoint[], xScale: number, yScale: number, min: number): string {
+  return data
+    .map((d, i) => `${i === 0 ? 'M' : 'L'}${i * xScale + PAD},${min - (d.value - min) * yScale + PAD}`)
+    .join(' ');
+}
+
+function formatValue(v: number, isPct: boolean): string {
+  return isPct ? `${v.toFixed(0)}%` : String(Math.round(v));
+}
+
+export function MetricTrajectory({
+  label,
+  data,
+  isPercentage = false,
+  color = 'accent',
+}: MetricTrajectoryProps) {
+  if (data.length < 2) return null;
+
+  const values = data.map((d) => d.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const xScale = (CHART_WIDTH - PAD * 2) / (data.length - 1);
+  const yScale = (CHART_HEIGHT - PAD * 2) / range;
+
+  const first = data[0].value;
+  const last = data[data.length - 1].value;
+  const trend = last > first ? 'up' : last < first ? 'down' : 'flat';
+
+  const strokeMap = {
+    accent: 'stroke-accent-9',
+    success: 'stroke-success-9',
+    warning: 'stroke-warning-9',
+    danger: 'stroke-danger-9',
+  };
+  const fillMap = {
+    accent: 'fill-accent-9',
+    success: 'fill-success-9',
+    warning: 'fill-warning-9',
+    danger: 'fill-danger-9',
+  };
+
+  return (
+    <div className="p-4 bg-neutral-2 rounded-lg border border-neutral-4">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-medium text-neutral-11">{label}</span>
+        <span className="flex items-center gap-1 text-xs text-neutral-9">
+          {trend === 'up' ? (
+            <TrendingUp className="w-3.5 h-3.5 text-success-9" />
+          ) : trend === 'down' ? (
+            <TrendingDown className="w-3.5 h-3.5 text-danger-9" />
+          ) : null}
+          {formatValue(last, isPercentage)}
+        </span>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className="w-full h-auto overflow-visible"
+        role="img"
+        aria-label={`${label}: ${data.map((d) => `${d.month} ${d.value}`).join(', ')}`}
+      >
+        {/* Grid lines */}
+        <line
+          x1={PAD}
+          y1={PAD}
+          x2={CHART_WIDTH - PAD}
+          y2={PAD}
+          className="stroke-neutral-4"
+          strokeWidth={1}
+        />
+        <line
+          x1={PAD}
+          y1={CHART_HEIGHT - PAD}
+          x2={CHART_WIDTH - PAD}
+          y2={CHART_HEIGHT - PAD}
+          className="stroke-neutral-4"
+          strokeWidth={1}
+        />
+
+        {/* Line */}
+        {data.length > 1 && (
+          <path
+            d={linePath(data, xScale, yScale, min)}
+            className={`${strokeMap[color]} fill-none`}
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        )}
+
+        {/* Data points */}
+        {data.map((d, i) => (
+          <circle
+            key={d.month}
+            cx={i * xScale + PAD}
+            cy={min - (d.value - min) * yScale + PAD}
+            r={3}
+            className={`${fillMap[color]} stroke-neutral-1`}
+            strokeWidth={1.5}
+          >
+            <title>{`${d.month}: ${formatValue(d.value, isPercentage)}`}</title>
+          </circle>
+        ))}
+
+        {/* Month labels */}
+        {data.map((d, i) => {
+          if (i % 2 !== 0 && data.length > 4) return null;
+          return (
+            <text
+              key={`label-${d.month}`}
+              x={i * xScale + PAD}
+              y={CHART_HEIGHT - 1}
+              textAnchor="middle"
+              className="fill-neutral-9 text-[8px]"
+            >
+              {d.month}
+            </text>
+          );
+        })}
+      </svg>
+
+      {/* Mini legend: first and last values */}
+      <div className="flex justify-between mt-1 text-[10px] text-neutral-9">
+        <span>{data[0].month} {formatValue(data[0].value, isPercentage)}</span>
+        <span>{data[data.length - 1].month} {formatValue(data[data.length - 1].value, isPercentage)}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ReportCard/MetricsTrajectoryPanel.tsx
+++ b/apps/web/src/components/ReportCard/MetricsTrajectoryPanel.tsx
@@ -1,5 +1,5 @@
 import { TrendingUp } from 'lucide-react';
-import { type MonthlyDataPoint, MetricTrajectory } from './MetricTrajectory';
+import { MetricTrajectory, type MonthlyDataPoint } from './MetricTrajectory';
 
 export interface TrajectoryMetric {
   label: string;
@@ -36,11 +36,6 @@ export function MetricsTrajectoryPanel({
           />
         ))}
       </div>
-      {metrics.length === 0 && (
-        <p className="text-sm text-neutral-7 italic">
-          Dados mensais ainda não disponíveis.
-        </p>
-      )}
     </section>
   );
 }

--- a/apps/web/src/components/ReportCard/MetricsTrajectoryPanel.tsx
+++ b/apps/web/src/components/ReportCard/MetricsTrajectoryPanel.tsx
@@ -1,0 +1,46 @@
+import { TrendingUp } from 'lucide-react';
+import { type MonthlyDataPoint, MetricTrajectory } from './MetricTrajectory';
+
+export interface TrajectoryMetric {
+  label: string;
+  data: MonthlyDataPoint[];
+  isPercentage?: boolean;
+  color?: 'accent' | 'success' | 'warning' | 'danger';
+}
+
+interface MetricsTrajectoryPanelProps {
+  title?: string;
+  metrics: TrajectoryMetric[];
+}
+
+export function MetricsTrajectoryPanel({
+  title = 'Evolução Mensal',
+  metrics,
+}: MetricsTrajectoryPanelProps) {
+  if (!metrics || metrics.length === 0) return null;
+
+  return (
+    <section className="mt-8">
+      <div className="flex items-center gap-2 mb-4">
+        <TrendingUp className="w-5 h-5 text-neutral-11" />
+        <h2 className="text-lg font-semibold text-neutral-11">{title}</h2>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {metrics.map((metric) => (
+          <MetricTrajectory
+            key={metric.label}
+            label={metric.label}
+            data={metric.data}
+            isPercentage={metric.isPercentage}
+            color={metric.color}
+          />
+        ))}
+      </div>
+      {metrics.length === 0 && (
+        <p className="text-sm text-neutral-7 italic">
+          Dados mensais ainda não disponíveis.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/ReportCard/ReportCardDetail.tsx
+++ b/apps/web/src/components/ReportCard/ReportCardDetail.tsx
@@ -23,6 +23,8 @@ import { useFeatureFlags } from '../../store/useFeatureFlags';
 import { HELP_TEXTS, HelpTooltip } from '../ui/HelpTooltip';
 import { GradeCircle } from './GradeCircle';
 import { MetricBar } from './MetricBar';
+import { MetricsTrajectoryPanel } from './MetricsTrajectoryPanel';
+import type { TrajectoryMetric } from './MetricsTrajectoryPanel';
 
 function SourceIndicator({
   sourceType,
@@ -64,6 +66,26 @@ function formatDate(dateStr: string | null): string {
   if (!dateStr) return 'presente';
   const date = new Date(dateStr);
   return date.toLocaleDateString('pt-PT', { month: 'short', year: 'numeric' });
+}
+
+/** Generate sample monthly trajectory data from current snapshot values.
+ *  Once a monthly data pipeline exists, replace this with real data. */
+function buildSampleTrajectories(deputy: DeputyDetail): TrajectoryMetric[] {
+  const months = ['Jan', 'Fev', 'Mar', 'Abr'];
+  const base = (v: number) => Math.max(1, Math.round(v * 0.8));
+  const spread = (v: number) => {
+    const b = base(v);
+    return months.map((m, i) => ({ month: m, value: Math.round(b + (v - b) * ((i + 1) / months.length)) }));
+  };
+
+  return [
+    { label: 'Propostas', data: spread(deputy.proposal_count), color: 'accent' },
+    { label: 'Intervenções', data: spread(deputy.intervention_count), color: 'accent' },
+    ...(deputy.attendance_rate !== null
+      ? [{ label: 'Presença', data: spread(deputy.attendance_rate).map((d) => ({ ...d, value: Math.min(100, d.value) })), isPercentage: true as const, color: 'success' as const }]
+      : []),
+    { label: 'Trabalho', data: spread(deputy.work_score).map((d) => ({ ...d, value: Math.min(100, d.value) })), isPercentage: true as const, color: 'accent' },
+  ];
 }
 
 export function ReportCardDetail({ deputy, averages, extendedInfo }: ReportCardDetailProps) {
@@ -215,6 +237,13 @@ export function ReportCardDetail({ deputy, averages, extendedInfo }: ReportCardD
             </div>
           )}
       </div>
+
+      {/* Monthly Trajectory Section */}
+      {flags.monthlyTrajectory && (
+        <div className="p-6 border-t border-neutral-5">
+          <MetricsTrajectoryPanel metrics={buildSampleTrajectories(deputy)} />
+        </div>
+      )}
 
       {/* Extended Info Section */}
       {extendedInfo && (

--- a/apps/web/src/components/ReportCard/index.ts
+++ b/apps/web/src/components/ReportCard/index.ts
@@ -4,3 +4,7 @@ export { DeputyCard } from './DeputyCard';
 export { PostalCodeInput } from './PostalCodeInput';
 export { ReportCardDetail } from './ReportCardDetail';
 export { DistrictDeputyList } from './DistrictDeputyList';
+export { MetricTrajectory } from './MetricTrajectory';
+export type { MonthlyDataPoint } from './MetricTrajectory';
+export { MetricsTrajectoryPanel } from './MetricsTrajectoryPanel';
+export type { TrajectoryMetric } from './MetricsTrajectoryPanel';

--- a/apps/web/src/store/useFeatureFlags.ts
+++ b/apps/web/src/store/useFeatureFlags.ts
@@ -14,6 +14,8 @@ export interface FeatureFlags {
   averageDisplay: boolean;
   /** Issue #5 - Question count is always 0 */
   questionCount: boolean;
+  /** BRU-882 - Monthly performance trajectory visualization */
+  monthlyTrajectory: boolean;
 }
 
 interface FeatureFlagsStore {
@@ -28,6 +30,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   downloadImage: false, // Hide until download is fixed
   averageDisplay: false, // Hide until average calculation is correct
   questionCount: false, // Hide until question count data is populated
+  monthlyTrajectory: false, // Hide until monthly data pipeline is ready
 };
 
 export const useFeatureFlags = create<FeatureFlagsStore>()(


### PR DESCRIPTION
## Summary

Adds monthly performance trajectory visualization components to Deputy Report Cards, showing how metrics evolved over the last 4 months.

## Changes

- **MetricTrajectory.tsx** — SVG sparkline line chart component for a single metric: responsive, with data points, trend indicator, month labels, and accessible `<title>` tooltips
- **MetricsTrajectoryPanel.tsx** — container section with heading and grid layout for multiple trajectory charts
- **Integration** — panel renders in `ReportCardDetail.tsx` gated behind the `monthlyTrajectory` feature flag (default: off)
- **Feature flag** — `monthlyTrajectory` added to `useFeatureFlags` store
- **Tests** — 26 tests for MetricTrajectory + MetricsTrajectoryPanel

## Data

Currently uses `buildSampleTrajectories()` to generate synthetic monthly data from current snapshot values. Replace with real monthly data once the data pipeline is in place.

## Testing

```
Test Files  24 passed (24)
Tests       558 passed (558)
```

All existing tests continue to pass.